### PR TITLE
WIP: Quick Connect, Audio Tracks & Next Up/Continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ misterfin-arm
 misterfin-preview
 mplayer-arm
 jellyfin.conf
+token.conf
+device.conf
 crash.log
 __pycache__/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRCS = src/main.c src/fb.c src/ddr.c src/jellyfin.c
+SRCS = src/main.c src/fb.c src/ddr.c src/jellyfin.c src/json.c src/subtitles.c
 
 TARGET     = misterfin
 TARGET_ARM = misterfin-arm
@@ -13,12 +13,26 @@ CFLAGS_ARM = -O2 -Isrc -DAPP_VERSION=\"$(VERSION)\" -D_FILE_OFFSET_BITS=64
 
 MISTER_HOST ?= mister.local
 
-.PHONY: all arm clean deploy
+.PHONY: all arm clean deploy test
 
 all: $(TARGET)
 
+# Unit tests. Host build only; neither of these has anything platform-specific
+# in it. The JSON parser sits under every server response the client reads;
+# the subtitle clean-up can only otherwise be checked during playback, which
+# needs real hardware.
+test:
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_json tests/test_json.c src/json.c
+	@/tmp/misterfin_test_json
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_subtitles \
+		tests/test_subtitles.c src/subtitles.c src/jellyfin.c src/json.c
+	@/tmp/misterfin_test_subtitles
+
+# -lm: stb_image needs pow(), the Toasty sprite paths need sinf/sincosf. The
+# ARM build gets libm folded into libc by zig's target libc, so only the host
+# build has to ask for it explicitly.
 $(TARGET): $(SRCS)
-	$(CC) $(CFLAGS) -o $@ $^ -lpthread
+	$(CC) $(CFLAGS) -o $@ $^ -lpthread -lm
 
 arm: $(SRCS)
 	$(CC_ARM) $(CFLAGS_ARM) -o $(TARGET_ARM) $^ -lpthread -ldl

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ test:
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_subtitles \
 		tests/test_subtitles.c src/subtitles.c src/jellyfin.c src/json.c
 	@/tmp/misterfin_test_subtitles
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_config \
+		tests/test_config.c src/jellyfin.c src/json.c
+	@mkdir -p /tmp/misterfin_test_cfgdir && cd /tmp/misterfin_test_cfgdir && /tmp/misterfin_test_config
 
 # -lm: stb_image needs pow(), the Toasty sprite paths need sinf/sincosf. The
 # ARM build gets libm folded into libc by zig's target libc, so only the host

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Quick Connect must be enabled server-side (Dashboard → General → Quick Conne
 
 **TV mode** is `PAL` or `NTSC`, optional, defaults to `PAL`. It's recognised wherever it appears in the file, so you don't have to pad the lines above it.
 
+**Transcode profile** is also optional, and likewise recognised wherever it appears — `WxH` or `WxH@BITRATE`, e.g. `640x480@12000000`. It sets what the server is asked to transcode video down to before mplayer scales it back up to fill the screen; the default is `480x270@8000000`. The active profile is shown on the pause screen so you can confirm which one is in effect.
+
+Raising it is the main lever on picture quality, and the main way to run out of CPU. Total pixel count is what costs decode time on this hardware — bitrate is close to free (2 Mbps and 8 Mbps both measured ~34% CPU with no A/V drift), while `720x576` was confirmed unsustainable: A/V desync grew continuously and the CPU saturated. `480x270` is the known-good default. Anything in between is unmeasured, so if you raise it, watch for audio drifting out of sync — that's the symptom that appears first.
+
 ### Using an API key instead
 
 Still supported, and unchanged if you already have one set up:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ tools/run-local.sh --ntsc -k "a"              # 240-line NTSC geometry instead o
 
 It needs a `./jellyfin.conf` in the repo root pointing at a real server (gitignored, same file `--preview-browse` expects). **Video playback is not usable this way** — mplayer writes straight into a real framebuffer, which a malloc'd buffer can't stand in for; everything else (browsing, info screens, music metadata, menus, auth) works normally.
 
+`MISTERFIN_INPUT_DEBUG=1` works on real hardware too, not just on a desktop: it prints every incoming input event with its device, raw code and what it mapped to (or why it was dropped) to stderr, so run it over SSH rather than from the Scripts menu. MiSTer's input routing is genuinely unusual — it grabs directly-wired USB pads exclusively and re-emits them on a synthetic "MiSTer virtual input" device — so if a button isn't doing anything, this says whether it's arriving at all and under which code.
+
 The underlying switches are plain environment variables if you'd rather drive them yourself: `MISTERFIN_FB=640x288` picks the headless buffer size, `MISTERFIN_FRAME_OUT=<path>` dumps each frame, `MISTERFIN_STDIN=1` reads the terminal, and `MISTERFIN_KEYS="right,a:800"` plays a scripted sequence (`MISTERFIN_KEYS_HOLD=1` to stay running afterwards instead of quitting).
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ The UI is currently tuned for PAL/NTSC-resolution CRT output (288p/240p) — it 
 
 ## Features
 
+- **Quick Connect sign-in** — no API key, no admin dashboard, no password typed on a gamepad. First launch shows a code; approve it from any device already signed into Jellyfin and the login is saved. A revoked login is detected and re-requested automatically. API keys still work for existing setups
+- **Continue Watching and Next Up** appear as the first two cards on the home screen, ahead of the libraries, and only when they have something in them. Episodes there show which series and which episode they are, since a row called "Episode 03" out of context identifies nothing
 - **Home screen** is a horizontal library carousel — name + item count per library, the active one centered, with a dimmed cover-art mosaic from that library filling the background. Every library gets its own slot along the strip (extras simply run off-screen rather than being hidden), and LEFT/RIGHT slides between them with the background fading through black. SELECT swaps to a classic list view instead, if you prefer that; either way, the selected library is remembered when you back out of one. B opens an exit-confirm dialog instead of quitting immediately, so a stray press can't silently close the app
 - **Browsing within a library** (movies/series/albums/episodes/tracks) uses a list with cover art per item, watched/resume badges, a live clock, and a scrolling marquee for titles too long to fit (e.g. "Artist / Album", "Series / Season"). Albums show year + track count, artists show album count, and series show season + episode count
 - **Info screen** with cover art, description, year, and status
 - **Video playback** is server-side transcoded with correct letterbox/pillarbox scaling for any source aspect ratio
 - **Pause menu** with a live progress bar, VSync ON/OFF toggle, resume/stop
-- **Subtitles** are rendered client-side (instant toggle/switch, no re-buffering) for text-based tracks, with a picker menu and live sync fine-tuning; image-based tracks (PGS/VobSub — no text to hand back client-side) fall back to a server-side burn-in automatically instead of silently failing to show
+- **Subtitles** are rendered client-side (instant toggle/switch, no re-buffering) for text-based tracks, with a picker menu and live sync fine-tuning; image-based tracks (PGS/VobSub — no text to hand back client-side) fall back to a server-side burn-in automatically instead of silently failing to show. ASS/SSA subtitles are cleaned up on the way in — inline override codes like `{\an8}` and `{\i1}` are stripped rather than drawn on screen as literal text
+- **Alternate audio tracks** — a second tab in the same SELECT menu lists every audio stream (language, codec, channel count, and whatever else the server puts in its display title, so a commentary track is distinguishable from the main mix). Switching restarts the stream at the current position, since the server transcodes one chosen track into what it sends
 - **Music library**: browse Artists → Albums → Tracks, direct-play audio (no server transcode needed for a plain FLAC/MP3 file), a now-playing screen with a live clock, cover art (falls back to the album's cover for a track with no embedded art of its own), a real audio-reactive VU meter pair (reads mplayer's own live PCM export, not a decorative animation), a SELECT-cycled background effect — starfield, rain, or a faithful port of [MiSTer-Toasty-Squadron](https://github.com/puddingstudio/MiSTer-Toasty-Squadron)'s own flying-toaster screensaver (same flight paths, sizes, and moon, right down to its biggest sprites flying over the cover art) — seek within a track, and prev/next-track navigation that auto-advances at the end of each track
 - **Sync**: resume position and watched status are read from and reported back to Jellyfin, so they stay in sync with your other Jellyfin clients
 - **About screen** with a GitHub-releases update check and one-button in-app update (A installs, applied on next launch); the same animated starfield background also shows on the setup screen if `jellyfin.conf` is missing/misconfigured
@@ -70,6 +73,21 @@ make deploy
 
 If you'd rather not build `mplayer-arm` yourself, MPlayer 1.5 built with `--enable-fbdev --enable-alsa` and the vsync patch in `docker/vo_fbdev.c` applied will work — that's exactly what `docker/build-mplayer.sh` automates.
 
+### Running it on a desktop
+
+`tools/run-local.sh` runs the real app on an ordinary Linux box, so UI and API work doesn't need a flash-and-look cycle for every change. There's no `/dev/fb0` to draw into, so the app is pointed at a plain malloc'd buffer of the same size and reads keys from the terminal instead of `/dev/input/eventN`; every frame is dumped and converted to a PNG by `tools/raw_to_png.py` (stdlib `zlib` only — no image library needed).
+
+```bash
+tools/run-local.sh                            # interactive: arrows, Enter, Esc, Tab, q to quit
+tools/run-local.sh -k "right,right,a"         # scripted, then screenshot the result
+tools/run-local.sh -k "down:200,a:1500" -o shot.png
+tools/run-local.sh --ntsc -k "a"              # 240-line NTSC geometry instead of PAL's 288
+```
+
+It needs a `./jellyfin.conf` in the repo root pointing at a real server (gitignored, same file `--preview-browse` expects). **Video playback is not usable this way** — mplayer writes straight into a real framebuffer, which a malloc'd buffer can't stand in for; everything else (browsing, info screens, music metadata, menus, auth) works normally.
+
+The underlying switches are plain environment variables if you'd rather drive them yourself: `MISTERFIN_FB=640x288` picks the headless buffer size, `MISTERFIN_FRAME_OUT=<path>` dumps each frame, `MISTERFIN_STDIN=1` reads the terminal, and `MISTERFIN_KEYS="right,a:800"` plays a scripted sequence (`MISTERFIN_KEYS_HOLD=1` to stay running afterwards instead of quitting).
+
 ---
 
 ## Installation
@@ -100,7 +118,24 @@ If you'd rather not build `mplayer-arm` yourself, MPlayer 1.5 built with `--enab
 
 ## Configuring `jellyfin.conf`
 
-Create `/media/fat/misterfin/jellyfin.conf` — 4 lines (see `jellyfin.conf.example`):
+Create `/media/fat/misterfin/jellyfin.conf`. The only line you actually need is your server:
+
+```
+http://<your-jellyfin-ip>:8096
+PAL
+```
+
+On first launch MiSTerFin shows a **Quick Connect** code. Open Jellyfin on any device where you're already signed in, go to your user menu → Quick Connect, and type the code in. That's it — the resulting login is saved to `token.conf` next to the config, so it's a one-time step. If the login is ever revoked, the app notices and asks again by itself.
+
+Two small files get written next to `jellyfin.conf` and don't need creating yourself: `token.conf` (the saved login) and `device.conf` (a random GUID identifying this install to the server). Delete `token.conf` to sign out. Don't copy `device.conf` between two MiSTers that use the same Jellyfin account — Jellyfin logs out any existing session sharing a device id, so they'd take turns signing each other out.
+
+Quick Connect must be enabled server-side (Dashboard → General → Quick Connect); it's on by default on most installs. If it's off, MiSTerFin says so and tells you the alternative.
+
+**TV mode** is `PAL` or `NTSC`, optional, defaults to `PAL`. It's recognised wherever it appears in the file, so you don't have to pad the lines above it.
+
+### Using an API key instead
+
+Still supported, and unchanged if you already have one set up:
 
 ```
 http://<your-jellyfin-ip>:8096
@@ -111,10 +146,15 @@ PAL
 
 1. **Server URL** — no trailing slash.
 2. **API key** — Jellyfin admin dashboard → Advanced → API Keys → **+**. Name it something recognizable like "MiSTerFin" when you create it — Jellyfin's Dashboard → Devices/Sessions shows the *key's own registered name* as the client, permanently fixed at creation time, not something MiSTerFin can override later (its actual version number still shows up correctly regardless). A generically-named key (or one created before you'd settled on a name) will just show that name instead — harmless, but confusing to look at later.
-3. **Username** — your plain Jellyfin username. MiSTerFin resolves it to the real user id via `GET /Users` at startup (the raw id isn't easily findable anywhere in the Jellyfin UI — it only shows up buried in a dashboard URL — but everyone already knows their own username).
-4. **TV mode** — `PAL` or `NTSC`. Optional, defaults to `PAL`.
+3. **Username** — your plain Jellyfin username. MiSTerFin resolves it to the real user id via `GET /Users` at startup.
 
-There is no on-screen setup keyboard in v1 — edit the file over SSH (using the standard MiSTer root password) or by pulling the SD card.
+Quick Connect is the better option where you have the choice. An API key isn't scoped to a user — it authenticates as the *server*, and which user's watch state gets written is decided entirely by the `userId` the client sends, resolved from the username on line 3. That works fine, but it's honour-system: the same key can read and write any account on the server, so it's a much broader credential than the job needs. It also requires admin dashboard access to create in the first place, and it's why playback progress has to be reported through a per-user endpoint rather than the normal session one (see `report_user_data` — `Sessions/Playing/Progress` silently does nothing without a real user session).
+
+A Quick Connect token *is* the user, so none of that applies: nothing to resolve, nothing to trust, and no access beyond that one account.
+
+A saved Quick Connect login takes precedence over an API key in the file, so re-authenticating once sticks even if an old key is left behind.
+
+There is no on-screen keyboard for the server URL — edit the file over SSH (using the standard MiSTer root password) or by pulling the SD card.
 
 ---
 
@@ -150,18 +190,24 @@ Button labels below follow Xbox-style naming (bottom face button = A, right face
 |--------|----------|--------|
 | B | Enter / X | Pause / resume |
 | Left / Right | Left / Right | Seek back/forward 30s (or adjust subtitle sync, in the subtitle menu) |
-| SELECT | Tab | Open the subtitle menu |
+| SELECT | Tab | Open the audio/subtitle track picker |
 | L | PageUp | VSync ON |
 | R | PageDown | VSync OFF |
 | A | Esc / Backspace / Z | Stop, back to browser |
 
-### Subtitle menu (SELECT during video playback)
+### Track picker (SELECT during video playback)
+
+Two tabs — **AUDIO** and **SUBTITLES** — switched with the shoulder buttons.
+
 | Button | Keyboard | Action |
 |--------|----------|--------|
-| Up / Down | Up / Down | Select subtitle track (or off) |
-| Left / Right | Left / Right | Adjust subtitle sync offset |
+| L / R | PageUp / PageDown | Switch between the AUDIO and SUBTITLES tabs |
+| Up / Down | Up / Down | Select a track (SUBTITLES also has an "Off" entry) |
+| Left / Right | Left / Right | Adjust subtitle sync offset (SUBTITLES tab only) |
 | B | Enter / X | Apply |
 | A / SELECT | Esc / Backspace / Z / Tab | Cancel |
+
+A `>` marks the track currently playing. Changing the **subtitle** track is instant for text-based tracks (rendered client-side). Changing the **audio** track always restarts the stream at the current position — Jellyfin transcodes one chosen audio stream into what it sends, so there's no way to switch it client-side the way a subtitle can be. Changing both at once costs a single restart, not two.
 
 VSync is ON by default (tear-free) — turn it OFF if you'd rather trade tearing for a bit more decode headroom.
 
@@ -193,6 +239,7 @@ Verified against a real Jellyfin 10.11 server: auth, browsing (views/items, incl
 - **Any mplayer slave command sent while paused silently resumes playback unless prefixed with `pausing_keep`.** This isn't Jellyfin/MiSTerFin-specific, just an mplayer slave-mode quirk — but it's the reason pause-state commands (subtitle visibility, seeking while paused) are all prefixed that way throughout `main.c`.
 - **Server-side subtitle burn-in (image-based tracks only) forces a full stream restart, and seeking with it active re-decodes from the true start of the file up to the seek target** — a multi-minute stall on a deep seek. Text-based tracks are unaffected (rendered client-side, no restart). See `jf_stream_url()`'s `burn_in_sub_index` comment.
 - **`MediaSourceId` is omitted** from stream/progress/subtitle requests rather than guessed — works for direct single-version items; multi-version items (multiple cuts/qualities of the same title) may not resolve to the version you expect.
+- **The on-screen font is ASCII-only**, so non-ASCII titles are transliterated rather than drawn as-is (`Amélie` → `Amelie`, `Zoë & Co.` → `Zoe & Co.`, smart quotes and em-dashes normalised). Accented Latin folds to its base letter; anything with no ASCII form — CJK, Cyrillic, Greek — collapses to a single `?`. See `jf_text_to_display()`. Fixing this properly means a larger font atlas, not a parsing change.
 - **No on-screen keyboard** for server setup — `jellyfin.conf` must be edited manually (SSH or SD card).
 - Silent failure if `mplayer-arm` can't open the stream (bad URL, server down, transcode rejected) — you're dropped back to the browser with no error message.
 

--- a/jellyfin.conf.example
+++ b/jellyfin.conf.example
@@ -1,13 +1,35 @@
 # MiSTerFin config — copy to /media/fat/misterfin/jellyfin.conf and fill in.
-# 4 lines, in order. Lines starting with # and blank lines are ignored.
+# Lines starting with # and blank lines are ignored.
 #
-# 1) Jellyfin server URL (no trailing slash)
-# 2) API key — Jellyfin admin dashboard -> Advanced -> API Keys -> +
-# 3) Your Jellyfin username (resolved to the real user id at startup —
-#    the raw id isn't easily findable in the Jellyfin UI, your username is)
-# 4) TV mode — PAL or NTSC (optional, defaults to PAL)
+# The server URL is the only line you need. On first launch MiSTerFin shows a
+# Quick Connect code: open Jellyfin on any device you're already signed in on,
+# go to your user menu -> Quick Connect, and enter it. The login is saved to
+# token.conf next to this file, so it only has to be done once.
+#
+# PAL or NTSC is optional (defaults to PAL) and is recognised on whichever
+# line it appears, so it doesn't have to sit below anything.
 
 http://192.168.2.10:8096
-your-api-key-here
-your-username-here
 PAL
+
+
+# ── Using an API key instead ────────────────────────────────────────────────
+# Still supported. Replace the two lines above with the four below:
+#
+#   1) Jellyfin server URL (no trailing slash)
+#   2) API key — Jellyfin admin dashboard -> Advanced -> API Keys -> +
+#   3) Your Jellyfin username (resolved to the real user id at startup —
+#      the raw id isn't easily findable in the Jellyfin UI, your username is)
+#   4) TV mode — PAL or NTSC (optional, defaults to PAL)
+#
+# http://192.168.2.10:8096
+# your-api-key-here
+# your-username-here
+# PAL
+#
+# Quick Connect is preferable where you have the choice. An API key isn't
+# scoped to a user: it authenticates as the server, and the username on line 3
+# only decides which account this client writes watch state to. That works,
+# but the same key can read and write any account on the server — a much
+# broader credential than the job needs — and creating one needs admin
+# dashboard access. A Quick Connect token simply is the user.

--- a/jellyfin.conf.example
+++ b/jellyfin.conf.example
@@ -8,6 +8,13 @@
 #
 # PAL or NTSC is optional (defaults to PAL) and is recognised on whichever
 # line it appears, so it doesn't have to sit below anything.
+#
+# So is the transcode profile: "WxH" or "WxH@BITRATE", e.g. 640x480@12000000.
+# It's what the server is asked to scale video down to before mplayer scales
+# it back up; the default is 480x270@8000000. Raising it is the main lever on
+# picture quality and the main way to run out of CPU — 720x576 is confirmed
+# unsustainable on this hardware (audio drifts out of sync and keeps
+# drifting). The pause screen shows which profile is actually in effect.
 
 http://192.168.2.10:8096
 PAL

--- a/src/fb.c
+++ b/src/fb.c
@@ -48,11 +48,71 @@ static void fpga_wait_vsync(void)
 }
 /* -------------------------------------------------------------------------- */
 
+/* Desktop/headless backend — fabricates an FBDev backed by plain malloc'd
+ * buffers so the whole app can run without a real /dev/fb0 (which needs
+ * fbdev ioctls a desktop Linux X/Wayland session doesn't provide). This is
+ * exactly what run_preview_browse() in main.c used to hand-roll for itself;
+ * having it here means the ordinary startup path works too, so the real UI
+ * can be driven end-to-end off-hardware.
+ *
+ * Deliberately gated on MISTERFIN_FB being set rather than falling back
+ * automatically when the real open fails: on the MiSTer a failed /dev/fb0
+ * open is a genuine error worth reporting, and silently substituting an
+ * invisible buffer would turn that into a mystery "app runs but nothing
+ * appears" instead. */
+static int fb_open_headless(FBDev *fb, const char *spec)
+{
+    int w = 0, h = 0;
+    if (sscanf(spec, "%dx%d", &w, &h) != 2 || w <= 0 || h <= 0) {
+        fprintf(stderr, "MISTERFIN_FB: expected WxH (e.g. 640x288), got \"%s\"\n", spec);
+        return -1;
+    }
+
+    fb->fd        = -1;
+    fb->width     = w;
+    fb->height    = h;
+    fb->stride    = w * 4;
+    fb->n_pages   = 1;
+    fb->mmap_size = (size_t)fb->stride * fb->height;
+    fb->headless  = 1;
+
+    fb->mem  = (uint8_t *)calloc(1, fb->mmap_size);
+    fb->back = (uint8_t *)calloc(1, fb->mmap_size);
+    if (!fb->mem || !fb->back) {
+        free(fb->mem); free(fb->back);
+        fb->mem = fb->back = NULL;
+        perror("alloc headless framebuffer");
+        return -1;
+    }
+    return 0;
+}
+
+/* Raw BGRX dump of the visible buffer, written on every fb_flip when
+ * MISTERFIN_FRAME_OUT names a path. Always overwrites, so the file simply
+ * holds the latest frame at all times — tools/raw_to_png.py turns it into
+ * something viewable (stdlib zlib only, no image library needed). Headless
+ * only: on real hardware this would be a per-frame disk write to the SD
+ * card for no benefit. */
+static void fb_dump_frame(const FBDev *fb)
+{
+    const char *out = getenv("MISTERFIN_FRAME_OUT");
+    if (!out || !*out) return;
+    FILE *f = fopen(out, "wb");
+    if (!f) return;
+    fwrite(fb->mem, 1, (size_t)fb->stride * fb->height, f);
+    fclose(f);
+}
+
 int fb_open(FBDev *fb, const char *path)
 {
-    fb->fd   = -1;
-    fb->mem  = NULL;
-    fb->back = NULL;
+    fb->fd       = -1;
+    fb->mem      = NULL;
+    fb->back     = NULL;
+    fb->headless = 0;
+
+    const char *headless_spec = getenv("MISTERFIN_FB");
+    if (headless_spec && *headless_spec)
+        return fb_open_headless(fb, headless_spec);
 
     fb->fd = open(path, O_RDWR);
     if (fb->fd < 0) { perror("open framebuffer"); return -1; }
@@ -98,7 +158,8 @@ void fb_close(FBDev *fb)
 {
     if (fb->back) { free(fb->back); fb->back = NULL; }
     if (fb->mem && fb->mem != MAP_FAILED) {
-        munmap(fb->mem, fb->mmap_size);
+        if (fb->headless) free(fb->mem);
+        else              munmap(fb->mem, fb->mmap_size);
         fb->mem = NULL;
     }
     if (fb->fd >= 0) { close(fb->fd); fb->fd = -1; }
@@ -118,13 +179,17 @@ void fb_flip(FBDev *fb)
      * at all — only mplayer's own separately-patched vo_fbdev had its own
      * wait — so anything drawing multiple fb_flip()s in quick succession
      * (the carousel's slide animation, in particular) tore visibly. */
-    uint32_t dummy = 0;
-    ioctl(fb->fd, FBIO_WAITFORVSYNC, &dummy);
+    if (!fb->headless) {
+        uint32_t dummy = 0;
+        ioctl(fb->fd, FBIO_WAITFORVSYNC, &dummy);
+    }
     memcpy(fb->mem, fb->back, (size_t)fb->stride * fb->height);
+    if (fb->headless) fb_dump_frame(fb);
 }
 
 void fb_wait_vsync(FBDev *fb)
 {
+    if (fb->headless) return;   /* no display to sync to */
     uint32_t dummy = 0;
     ioctl(fb->fd, FBIO_WAITFORVSYNC, &dummy);
 }

--- a/src/fb.h
+++ b/src/fb.h
@@ -10,8 +10,13 @@ typedef struct {
     int      stride;    /* bytes per row */
     int      n_pages;   /* 1 or 2 (double-buffered fbdev) */
     size_t   mmap_size; /* total mmap'd bytes (stride * height * n_pages) */
+    int      headless;  /* 1 = plain malloc'd buffers, no real fbdev (see fb_open) */
 } FBDev;
 
+/* Opens the real fbdev at `path`, UNLESS the MISTERFIN_FB environment
+ * variable is set — in which case it fabricates an equivalent FBDev backed
+ * by plain malloc'd buffers instead (see fb_open's own comment). Format is
+ * "WxH", e.g. MISTERFIN_FB=640x288 for PAL, 640x240 for NTSC. */
 int  fb_open(FBDev *fb, const char *path);
 void fb_close(FBDev *fb);
 void fb_clear(FBDev *fb);   /* clear back-buffer to black */

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -1,4 +1,5 @@
 #include "jellyfin.h"
+#include "json.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,32 +7,25 @@
 #include <strings.h>
 #include <unistd.h>
 #include <time.h>
-#include <pthread.h>
-
-#define JF_BUF_SIZE   (256 * 1024)
-#define JF_ITEM_BUF   (JF_OVERVIEW_LEN + JF_NAME_LEN + 512)
 
 #ifndef APP_VERSION
 #define APP_VERSION "dev"
 #endif
-/* Client/Device/DeviceId/Version identify us to Jellyfin's own Dashboard →
- * Devices list — without them the server had nothing to go on beyond the
- * bare API token and showed up as a generic/guessed name instead of
- * "MiSTerFin". DeviceId is a fixed string rather than something derived
- * per-install (e.g. a MAC address) — multiple MiSTers would show up as one
- * "device" to Jellyfin, an acceptable trade-off for how small this project
- * is; nothing here is used for anything security-sensitive. */
+/* Client/Device/Version identify us to Jellyfin's own Dashboard → Devices
+ * list — without them the server had nothing to go on beyond the bare token
+ * and showed up as a generic/guessed name instead of "MiSTerFin". DeviceId is
+ * appended separately by jf_auth_header, since it's per-install rather than a
+ * compile-time constant (see JfConfig.device_id for why that matters). */
 #define JF_CLIENT_HEADERS \
-    "Client=\"MiSTerFin\", Device=\"MiSTer FPGA\", DeviceId=\"misterfin-client\", Version=\"" APP_VERSION "\", "
+    "Client=\"MiSTerFin\", Device=\"MiSTer FPGA\", Version=\"" APP_VERSION "\""
 
-/* Every jf_* function below that fetches+parses a response uses its own
- * function-local "static char buf[JF_BUF_SIZE]" — fine when everything runs
- * on one thread, but the home screen's background grid-cache prefetch
- * thread (main.c) calls some of these same functions concurrently with the
- * main thread. One coarse mutex around each of those functions' bodies is
- * enough: these are all short, sequential fetch+parse calls (no real
- * parallelism to lose), so serializing them costs nothing meaningful. */
-static pthread_mutex_t g_jf_mutex = PTHREAD_MUTEX_INITIALIZER;
+/* There is deliberately no lock in this file any more. Each fetch now reads
+ * into its own heap buffer instead of a function-local "static char
+ * buf[256K]", so two threads calling in at once (the home screen's
+ * background cover prefetch does exactly that) no longer share anything
+ * mutable. The mutex that used to serialize every request existed solely to
+ * protect those static buffers — dropping it lets the prefetch thread
+ * actually run in parallel with the main thread instead of taking turns. */
 
 /* Ids and image tags below (item_id, series_id, season_id, parent_id, the
  * ImageTags.Primary hash) come from server JSON and get embedded into
@@ -49,127 +43,175 @@ static void jf_sanitize_id(const char *in, char *out, int outlen)
     out[i] = '\0';
 }
 
-/* ── tiny flat-key JSON extractors (same technique as MiSTerDVD's json_str,
- *    adapted with int64/bool variants; safe because Jellyfin's per-item
- *    field names — Name, Overview, ProductionYear, RunTimeTicks, Played,
- *    PlaybackPositionTicks, Primary — are unique enough within one item's
- *    JSON object that a flat strstr scan cannot cross into a sibling field
- *    with a colliding name). ────────────────────────────────────────────── */
+/* ── text for an ASCII-only display ──────────────────────────────────────── */
 
-static int json_str(const char *buf, const char *key, char *out, int maxlen)
+/* Folds UTF-8 down to the ASCII the on-screen bitmap font can actually draw
+ * (src/font8x8.h covers 0x00-0x7F and nothing else; draw_char turns anything
+ * above that into '?').
+ *
+ * This became necessary the moment escapes were decoded properly. Jellyfin
+ * escapes every non-ASCII character as \uXXXX, and the old scanner emitted
+ * the escape's own letters verbatim — so "Amélie" reached the screen as
+ * "Amu00e9lie". Decoding it correctly yields real UTF-8, which without this
+ * would render as "Am??lie": more honest, but no more readable. Folding to
+ * the base letter gives "Amelie", which is what someone actually wants to
+ * see on a CRT.
+ *
+ * Accents are dropped rather than approximated with digraphs, except where a
+ * digraph IS the conventional transliteration (ß→ss, Æ→AE). Anything with no
+ * sensible ASCII form collapses to a single '?' per run, so a CJK title
+ * reads as "?" rather than a wall of one '?' per byte. */
+static void append_ascii(char *out, int outlen, int *pos, const char *s)
 {
-    char pat[80];
-    snprintf(pat, sizeof(pat), "\"%s\"", key);
-    const char *p = strstr(buf, pat);
-    if (!p) return 0;
-    p += strlen(pat);
-    while (*p == ' ' || *p == ':') p++;
-    if (*p != '"') return 0;
-    p++;
-    int i = 0;
-    while (*p && *p != '"' && i < maxlen - 1) {
-        if (*p == '\\') {
-            p++;
-            if (*p == 'n' || *p == 'r') out[i++] = ' ';
-            else if (*p) out[i++] = *p;
-        } else {
-            out[i++] = *p;
-        }
-        p++;
+    while (*s && *pos < outlen - 1) out[(*pos)++] = *s++;
+}
+
+static const char *fold_codepoint(unsigned cp)
+{
+    /* Latin-1 Supplement, in code-point order from U+00C0. */
+    static const char *const latin1[] = {
+        "A","A","A","A","A","A","AE","C","E","E","E","E","I","I","I","I",
+        "D","N","O","O","O","O","O","x","O","U","U","U","U","Y","Th","ss",
+        "a","a","a","a","a","a","ae","c","e","e","e","e","i","i","i","i",
+        "d","n","o","o","o","o","o","/","o","u","u","u","u","y","th","y"
+    };
+    /* Latin Extended-A, U+0100..U+017F — base letters only; the pattern is
+     * regular enough that a flat table is clearer than per-range rules. */
+    static const char *const latin_a[] = {
+        "A","a","A","a","A","a","C","c","C","c","C","c","C","c","D","d",
+        "D","d","E","e","E","e","E","e","E","e","E","e","G","g","G","g",
+        "G","g","G","g","H","h","H","h","I","i","I","i","I","i","I","i",
+        "I","i","IJ","ij","J","j","K","k","k","L","l","L","l","L","l","L",
+        "l","L","l","N","n","N","n","N","n","n","N","n","O","o","O","o",
+        "O","o","OE","oe","R","r","R","r","R","r","S","s","S","s","S","s",
+        "S","s","T","t","T","t","T","t","U","u","U","u","U","u","U","u",
+        "U","u","U","u","W","w","Y","y","Y","Z","z","Z","z","Z","z","s"
+    };
+
+    if (cp >= 0xC0 && cp <= 0xFF) return latin1[cp - 0xC0];
+    if (cp >= 0x100 && cp <= 0x17F) return latin_a[cp - 0x100];
+
+    switch (cp) {
+    case 0xA0: return " ";           /* non-breaking space */
+    case 0xAB: return "\"";          /* « */
+    case 0xBB: return "\"";          /* » */
+    case 0x2010: case 0x2011:
+    case 0x2012: case 0x2013:
+    case 0x2014: case 0x2015: return "-";
+    case 0x2018: case 0x2019:
+    case 0x201A: case 0x201B: return "'";
+    case 0x201C: case 0x201D:
+    case 0x201E: case 0x201F: return "\"";
+    case 0x2026: return "...";
+    case 0x2032: return "'";
+    case 0x2033: return "\"";
+    case 0x20AC: return "EUR";
+    case 0x2122: return "TM";
+    default: return NULL;
     }
-    out[i] = '\0';
-    return 1;
 }
 
-static int json_double(const char *buf, const char *key, double *out)
+/* Decodes one UTF-8 sequence at *s, advancing it. Returns the code point, or
+ * 0xFFFD for an invalid sequence (consuming one byte so it always makes
+ * progress). */
+static unsigned utf8_next(const char **s)
 {
-    char pat[80];
-    snprintf(pat, sizeof(pat), "\"%s\"", key);
-    const char *p = strstr(buf, pat);
-    if (!p) return 0;
-    p += strlen(pat);
-    while (*p == ' ' || *p == ':') p++;
-    if (!(*p == '-' || *p == '.' || (*p >= '0' && *p <= '9'))) return 0;
-    *out = strtod(p, NULL);
-    return 1;
+    const unsigned char *p = (const unsigned char *)*s;
+    unsigned c = *p;
+
+    int extra;
+    unsigned cp;
+    if      (c < 0x80)         { *s += 1; return c; }
+    else if ((c & 0xE0) == 0xC0) { extra = 1; cp = c & 0x1F; }
+    else if ((c & 0xF0) == 0xE0) { extra = 2; cp = c & 0x0F; }
+    else if ((c & 0xF8) == 0xF0) { extra = 3; cp = c & 0x07; }
+    else                       { *s += 1; return 0xFFFD; }
+
+    for (int i = 1; i <= extra; i++) {
+        if ((p[i] & 0xC0) != 0x80) { *s += 1; return 0xFFFD; }
+        cp = (cp << 6) | (p[i] & 0x3F);
+    }
+    *s += extra + 1;
+    return cp;
 }
 
-static int json_int64(const char *buf, const char *key, int64_t *out)
+void jf_text_to_display(const char *utf8, char *out, int outlen)
 {
-    char pat[80];
-    snprintf(pat, sizeof(pat), "\"%s\"", key);
-    const char *p = strstr(buf, pat);
-    if (!p) return 0;
-    p += strlen(pat);
-    while (*p == ' ' || *p == ':') p++;
-    if (!(*p == '-' || (*p >= '0' && *p <= '9'))) return 0;
-    *out = strtoll(p, NULL, 10);
-    return 1;
-}
+    if (!out || outlen <= 0) return;
+    out[0] = '\0';
+    if (!utf8) return;
 
-static int json_bool(const char *buf, const char *key, int *out)
-{
-    char pat[80];
-    snprintf(pat, sizeof(pat), "\"%s\"", key);
-    const char *p = strstr(buf, pat);
-    if (!p) return 0;
-    p += strlen(pat);
-    while (*p == ' ' || *p == ':') p++;
-    if (strncmp(p, "true", 4) == 0)  { *out = 1; return 1; }
-    if (strncmp(p, "false", 5) == 0) { *out = 0; return 1; }
-    return 0;
-}
+    int pos = 0;
+    int last_was_unknown = 0;
+    const char *s = utf8;
 
-/* Extracts the first quoted string from a "key":[ "a", "b", ... ] array
- * (used for BackdropImageTags — we only ever want the first backdrop). */
-static int json_first_array_str(const char *buf, const char *key, char *out, int maxlen)
-{
-    char pat[80];
-    snprintf(pat, sizeof(pat), "\"%s\":[", key);
-    const char *p = strstr(buf, pat);
-    if (!p) return 0;
-    p += strlen(pat);
-    while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
-    if (*p != '"') return 0;   /* empty array or not a string array */
-    p++;
-    int i = 0;
-    while (*p && *p != '"' && i < maxlen - 1) out[i++] = *p++;
-    out[i] = '\0';
-    return 1;
-}
+    while (*s && pos < outlen - 1) {
+        unsigned cp = utf8_next(&s);
 
-/* Returns pointer to the matching closing brace for the object starting at
- * obj_start (which must point at '{'), or NULL. Skips braces inside strings. */
-static const char *json_find_obj_end(const char *obj_start)
-{
-    int depth = 0, in_str = 0;
-    for (const char *p = obj_start; *p; p++) {
-        if (in_str) {
-            if (*p == '\\') { p++; continue; }
-            if (*p == '"') in_str = 0;
+        if (cp < 0x80) {
+            /* Newlines inside an overview would break single-line layout;
+             * the previous implementation flattened them to spaces too. */
+            out[pos++] = (cp == '\n' || cp == '\r' || cp == '\t') ? ' ' : (char)cp;
+            last_was_unknown = 0;
             continue;
         }
-        if (*p == '"') { in_str = 1; continue; }
-        if (*p == '{') depth++;
-        else if (*p == '}') { depth--; if (depth == 0) return p; }
+
+        const char *rep = fold_codepoint(cp);
+        if (rep) {
+            append_ascii(out, outlen, &pos, rep);
+            last_was_unknown = 0;
+        } else if (!last_was_unknown) {
+            out[pos++] = '?';
+            last_was_unknown = 1;   /* collapse a run into a single '?' */
+        }
     }
-    return NULL;
+    out[pos] = '\0';
 }
+
+/* json_copy_str + jf_text_to_display in one step — every string that ends up
+ * on screen goes through this, so none of them can skip the fold. */
+static int copy_display_str(const JsonDoc *doc, const JsonNode *from,
+                             const char *path, char *out, int outlen)
+{
+    const JsonNode *n = json_find(doc, from, path);
+    const char *s = json_as_str(n, NULL);
+    if (!s) { if (outlen > 0) out[0] = '\0'; return 0; }
+    jf_text_to_display(s, out, outlen);
+    return 1;
+}
+
+/* Ids and image tags are opaque hex/GUID strings that never get displayed —
+ * copy them verbatim, no folding. */
+static int copy_raw_str(const JsonDoc *doc, const JsonNode *from,
+                         const char *path, char *out, int outlen)
+{
+    return json_copy_str(doc, from, path, out, outlen);
+}
+
+/* ── item parsing ────────────────────────────────────────────────────────── */
 
 /* Fills in the fields shared by a browse-list row and a full single-item
  * fetch. Does NOT touch cast — that's only ever populated by
  * jf_get_item_details() via parse_cast(), since it needs Fields=People
- * (an extra cost we don't want on every row of every browse list). */
-static void parse_item_fields(const char *item_buf, JfItem *it)
+ * (an extra cost we don't want on every row of every browse list).
+ *
+ * `item` is the item's own object node, so every lookup below is scoped to
+ * it. That scoping is the point: these same field names (Name, Type, Id)
+ * also appear inside the nested People and MediaStreams arrays, and the
+ * previous flat text search found whichever copy happened to come first in
+ * the byte stream. It got the right answer only because Jellyfin's C# DTO
+ * declares Type before People — an ordering no one upstream knows is load
+ * bearing. */
+static void parse_item_fields(const JsonDoc *doc, const JsonNode *item, JfItem *it)
 {
     memset(it, 0, sizeof(*it));
     it->index_number = -1;
 
-    json_str(item_buf, "Id",   it->id,   sizeof(it->id));
-    json_str(item_buf, "Name", it->name, sizeof(it->name));
-    json_str(item_buf, "Overview", it->overview, sizeof(it->overview));
-    json_str(item_buf, "Primary", it->image_tag, sizeof(it->image_tag));
-    json_double(item_buf, "CommunityRating", &it->community_rating);
+    copy_raw_str    (doc, item, "Id",       it->id,       sizeof(it->id));
+    copy_display_str(doc, item, "Name",     it->name,     sizeof(it->name));
+    copy_display_str(doc, item, "Overview", it->overview, sizeof(it->overview));
+    copy_raw_str    (doc, item, "ImageTags.Primary", it->image_tag, sizeof(it->image_tag));
+    it->community_rating = json_as_dbl(json_find(doc, item, "CommunityRating"), 0.0);
 
     strncpy(it->image_item_id,    it->id, sizeof(it->image_item_id) - 1);
     strncpy(it->backdrop_item_id, it->id, sizeof(it->backdrop_item_id) - 1);
@@ -183,8 +225,8 @@ static void parse_item_fields(const char *item_buf, JfItem *it)
      * until this fallback, other albums whose files DO have embedded art
      * were unaffected). Same pattern as the Logo/Backdrop fallback below. */
     if (!it->image_tag[0]) {
-        if (json_str(item_buf, "AlbumPrimaryImageTag", it->image_tag, sizeof(it->image_tag)))
-            json_str(item_buf, "AlbumId", it->image_item_id, sizeof(it->image_item_id));
+        if (copy_raw_str(doc, item, "AlbumPrimaryImageTag", it->image_tag, sizeof(it->image_tag)))
+            copy_raw_str(doc, item, "AlbumId", it->image_item_id, sizeof(it->image_item_id));
     }
 
     /* Episodes/seasons normally don't carry their own Logo/BackdropImageTags —
@@ -194,17 +236,16 @@ static void parse_item_fields(const char *item_buf, JfItem *it)
      * episode's own ImageTags has no "Logo" key and BackdropImageTags is
      * empty, which is why the info screen for any TV episode never showed a
      * backdrop/logo before this fallback — not specific to one show. */
-    if (!json_str(item_buf, "Logo", it->logo_tag, sizeof(it->logo_tag))) {
-        if (json_str(item_buf, "ParentLogoImageTag", it->logo_tag, sizeof(it->logo_tag)))
-            json_str(item_buf, "ParentLogoItemId", it->logo_item_id, sizeof(it->logo_item_id));
+    if (!copy_raw_str(doc, item, "ImageTags.Logo", it->logo_tag, sizeof(it->logo_tag))) {
+        if (copy_raw_str(doc, item, "ParentLogoImageTag", it->logo_tag, sizeof(it->logo_tag)))
+            copy_raw_str(doc, item, "ParentLogoItemId", it->logo_item_id, sizeof(it->logo_item_id));
     }
-    if (!json_first_array_str(item_buf, "BackdropImageTags", it->backdrop_tag, sizeof(it->backdrop_tag))) {
-        if (json_first_array_str(item_buf, "ParentBackdropImageTags", it->backdrop_tag, sizeof(it->backdrop_tag)))
-            json_str(item_buf, "ParentBackdropItemId", it->backdrop_item_id, sizeof(it->backdrop_item_id));
+    if (!copy_raw_str(doc, item, "BackdropImageTags[0]", it->backdrop_tag, sizeof(it->backdrop_tag))) {
+        if (copy_raw_str(doc, item, "ParentBackdropImageTags[0]", it->backdrop_tag, sizeof(it->backdrop_tag)))
+            copy_raw_str(doc, item, "ParentBackdropItemId", it->backdrop_item_id, sizeof(it->backdrop_item_id));
     }
 
-    char type_buf[24] = {0};
-    json_str(item_buf, "Type", type_buf, sizeof(type_buf));
+    const char *type_buf = json_as_str(json_find(doc, item, "Type"), "");
     if      (!strcmp(type_buf, "Series"))       it->type = JF_TYPE_SERIES;
     else if (!strcmp(type_buf, "Season"))        it->type = JF_TYPE_SEASON;
     else if (!strcmp(type_buf, "Episode"))       it->type = JF_TYPE_EPISODE;
@@ -217,186 +258,257 @@ static void parse_item_fields(const char *item_buf, JfItem *it)
     else                                          it->type = JF_TYPE_OTHER;
 
     if (it->type == JF_TYPE_TRACK) {
-        json_str(item_buf, "Album", it->album, sizeof(it->album));
-        json_str(item_buf, "AlbumArtist", it->artist, sizeof(it->artist));
+        copy_display_str(doc, item, "Album",       it->album,  sizeof(it->album));
+        copy_display_str(doc, item, "AlbumArtist", it->artist, sizeof(it->artist));
     }
+    if (it->type == JF_TYPE_EPISODE)
+        copy_display_str(doc, item, "SeriesName", it->series_name, sizeof(it->series_name));
 
-    json_str(item_buf, "CollectionType", it->collection_type, sizeof(it->collection_type));
+    copy_raw_str(doc, item, "CollectionType", it->collection_type, sizeof(it->collection_type));
 
-    int64_t year = 0;
-    if (json_int64(item_buf, "ProductionYear", &year))
-        snprintf(it->year, sizeof(it->year), "%lld", (long long)year);
+    int64_t year = json_as_i64(json_find(doc, item, "ProductionYear"), 0);
+    if (year > 0) snprintf(it->year, sizeof(it->year), "%lld", (long long)year);
 
-    json_int64(item_buf, "RunTimeTicks", &it->runtime_ticks);
+    it->runtime_ticks        = json_as_i64(json_find(doc, item, "RunTimeTicks"), 0);
+    it->child_count          = (int)json_as_i64(json_find(doc, item, "ChildCount"), 0);
+    it->recursive_item_count = (int)json_as_i64(json_find(doc, item, "RecursiveItemCount"), 0);
+    it->index_number         = (int)json_as_i64(json_find(doc, item, "IndexNumber"), -1);
+    it->parent_index_number  = (int)json_as_i64(json_find(doc, item, "ParentIndexNumber"), -1);
 
-    int64_t child_count = 0;
-    if (json_int64(item_buf, "ChildCount", &child_count))
-        it->child_count = (int)child_count;
-
-    int64_t idx_num;
-    if (json_int64(item_buf, "IndexNumber", &idx_num))
-        it->index_number = (int)idx_num;
-
-    json_int64(item_buf, "PlaybackPositionTicks", &it->resume_ticks);
-    json_bool(item_buf, "Played", &it->played);
+    /* Scoped to UserData rather than searched for loose: PlayedPercentage and
+     * UnplayedItemCount live in the same object, and a bare "Played" search
+     * was one rename away from matching the wrong one. */
+    it->resume_ticks = json_as_i64 (json_find(doc, item, "UserData.PlaybackPositionTicks"), 0);
+    it->played       = json_as_bool(json_find(doc, item, "UserData.Played"), 0);
 }
 
 /* Populates it->cast[] (Actor entries only, first JF_MAX_CAST of them) from
- * a "People":[ ... ] array anywhere in buf. */
-static void parse_cast(const char *buf, JfItem *it)
+ * the item's People array. */
+static void parse_cast(const JsonDoc *doc, const JsonNode *item, JfItem *it)
 {
     it->cast_count = 0;
-    const char *p = strstr(buf, "\"People\":[");
-    if (!p) return;
-    p = strchr(p, '[');
-    if (!p) return;
-    p++;
+    const JsonNode *people = json_find(doc, item, "People");
+    if (!people) return;
 
-    while (it->cast_count < JF_MAX_CAST) {
-        while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t' || *p == ',') p++;
-        if (*p != '{') break;
-        const char *end = json_find_obj_end(p);
-        if (!end) break;
+    JSON_FOREACH(doc, people, person_node) {
+        if (it->cast_count >= JF_MAX_CAST) break;
+        if (strcmp(json_as_str(json_find(doc, person_node, "Type"), ""), "Actor") != 0)
+            continue;
 
-        int len = (int)(end - p + 1);
-        char person_buf[768];
-        if (len > (int)sizeof(person_buf) - 1) len = (int)sizeof(person_buf) - 1;
-        memcpy(person_buf, p, len);
-        person_buf[len] = '\0';
-
-        char type_buf[24] = {0};
-        json_str(person_buf, "Type", type_buf, sizeof(type_buf));
-        if (!strcmp(type_buf, "Actor")) {
-            JfPerson *person = &it->cast[it->cast_count];
-            memset(person, 0, sizeof(*person));
-            json_str(person_buf, "Id", person->id, sizeof(person->id));
-            json_str(person_buf, "Name", person->name, sizeof(person->name));
-            json_str(person_buf, "Role", person->role, sizeof(person->role));
-            json_str(person_buf, "PrimaryImageTag", person->image_tag, sizeof(person->image_tag));
-            it->cast_count++;
-        }
-
-        p = end + 1;
+        JfPerson *person = &it->cast[it->cast_count];
+        memset(person, 0, sizeof(*person));
+        copy_raw_str    (doc, person_node, "Id",              person->id,        sizeof(person->id));
+        copy_display_str(doc, person_node, "Name",            person->name,      sizeof(person->name));
+        copy_display_str(doc, person_node, "Role",            person->role,      sizeof(person->role));
+        copy_raw_str    (doc, person_node, "PrimaryImageTag", person->image_tag, sizeof(person->image_tag));
+        it->cast_count++;
     }
 }
 
-/* Populates it->subs[] and it->source_* from a "MediaStreams":[ ... ] array
- * anywhere in buf (confirmed shape on a real server: Type is the string
+/* Populates it->subs[], it->audio[] and it->source_* from the item's
+ * MediaStreams array (confirmed shape on a real server: Type is the string
  * "Subtitle"/"Video"/"Audio" — not the numeric enum some other Jellyfin API
- * responses use). Subtitle label prefers Language; external/undefined
- * tracks often have no Language, so DisplayTitle is the fallback. Only the
- * first Video stream's specs are kept (source_* is for display only, next
- * to the subtitle picker — what's actually streamed is JfStreamProfile). */
-static void parse_media_streams(const char *buf, JfItem *it)
+ * responses use). Only the first Video stream's specs are kept (source_* is
+ * for display only, next to the track pickers — what's actually streamed is
+ * JfStreamProfile). */
+static void parse_media_streams(const JsonDoc *doc, const JsonNode *item, JfItem *it)
 {
     it->sub_count = 0;
+    it->audio_count = 0;
     it->source_video_codec[0] = '\0';
     it->source_width = it->source_height = 0;
     it->source_bitrate = 0;
     it->source_aspect = 0.0;
     int got_video = 0;
 
-    const char *p = strstr(buf, "\"MediaStreams\":[");
-    if (!p) return;
-    p = strchr(p, '[');
-    if (!p) return;
-    p++;
+    const JsonNode *streams = json_find(doc, item, "MediaStreams");
+    if (!streams) return;
 
-    while (1) {
-        while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t' || *p == ',') p++;
-        if (*p != '{') break;
-        const char *end = json_find_obj_end(p);
-        if (!end) break;
+    JSON_FOREACH(doc, streams, stream) {
+        const char *type_buf = json_as_str(json_find(doc, stream, "Type"), "");
 
-        int len = (int)(end - p + 1);
-        char stream_buf[768];
-        if (len > (int)sizeof(stream_buf) - 1) len = (int)sizeof(stream_buf) - 1;
-        memcpy(stream_buf, p, len);
-        stream_buf[len] = '\0';
-
-        char type_buf[24] = {0};
-        json_str(stream_buf, "Type", type_buf, sizeof(type_buf));
         if (!strcmp(type_buf, "Subtitle") && it->sub_count < JF_MAX_SUBS) {
             JfSubtitle *sub = &it->subs[it->sub_count];
             memset(sub, 0, sizeof(*sub));
-            int64_t idx = 0;
-            json_int64(stream_buf, "Index", &idx);
-            sub->index = (int)idx;
-            if (!json_str(stream_buf, "Language", sub->label, sizeof(sub->label)) || !sub->label[0])
-                json_str(stream_buf, "DisplayTitle", sub->label, sizeof(sub->label));
-            json_str(stream_buf, "Codec", sub->codec, sizeof(sub->codec));
+            sub->index = (int)json_as_i64(json_find(doc, stream, "Index"), 0);
+            /* DisplayTitle first, Language only as a fallback. Language alone
+             * is not enough to tell two tracks apart, and that's the common
+             * case rather than an edge one: a release with English dialogue
+             * subtitles AND an English signs/songs or forced track shows up
+             * as two identical "eng" rows, with no way to know which is
+             * which except by picking one and watching.
+             *
+             * The server already composes what's needed — DisplayTitle leads
+             * with the track's own Title when it has one ("Signs & Songs"),
+             * then appends whichever of Hearing Impaired / Default / Forced /
+             * codec / External apply. Worth preferring even though it's
+             * longer: if it overflows the label it's the trailing codec and
+             * External tags that get cut, which are the least useful parts. */
+            if (!copy_display_str(doc, stream, "DisplayTitle", sub->label, sizeof(sub->label)) ||
+                !sub->label[0])
+                copy_display_str(doc, stream, "Language", sub->label, sizeof(sub->label));
+            copy_raw_str(doc, stream, "Codec", sub->codec, sizeof(sub->codec));
+            sub->is_forced  = json_as_bool(json_find(doc, stream, "IsForced"), 0);
+            sub->is_default = json_as_bool(json_find(doc, stream, "IsDefault"), 0);
             it->sub_count++;
+
+        } else if (!strcmp(type_buf, "Audio") && it->audio_count < JF_MAX_AUDIO) {
+            JfAudioTrack *aud = &it->audio[it->audio_count];
+            memset(aud, 0, sizeof(*aud));
+            aud->index    = (int)json_as_i64(json_find(doc, stream, "Index"), 0);
+            aud->channels = (int)json_as_i64(json_find(doc, stream, "Channels"), 0);
+            aud->is_default = json_as_bool(json_find(doc, stream, "IsDefault"), 0);
+            copy_raw_str(doc, stream, "Codec", aud->codec, sizeof(aud->codec));
+            /* DisplayTitle first here, unlike subtitles: the server composes
+             * it as e.g. "English - Dolby Digital 5.1 - Default", which is
+             * exactly what a track picker wants to show. Language alone
+             * can't distinguish two English tracks (a commentary from the
+             * main mix), which is the common case worth getting right. */
+            if (!copy_display_str(doc, stream, "DisplayTitle", aud->label, sizeof(aud->label)) ||
+                !aud->label[0])
+                copy_display_str(doc, stream, "Language", aud->label, sizeof(aud->label));
+            it->audio_count++;
+
         } else if (!strcmp(type_buf, "Video") && !got_video) {
             got_video = 1;
-            json_str(stream_buf, "Codec", it->source_video_codec, sizeof(it->source_video_codec));
-            int64_t w = 0, h = 0, br = 0;
-            json_int64(stream_buf, "Width", &w);
-            json_int64(stream_buf, "Height", &h);
-            json_int64(stream_buf, "BitRate", &br);
-            it->source_width = (int)w;
-            it->source_height = (int)h;
-            it->source_bitrate = br;
+            copy_raw_str(doc, stream, "Codec", it->source_video_codec, sizeof(it->source_video_codec));
+            it->source_width   = (int)json_as_i64(json_find(doc, stream, "Width"), 0);
+            it->source_height  = (int)json_as_i64(json_find(doc, stream, "Height"), 0);
+            it->source_bitrate = json_as_i64(json_find(doc, stream, "BitRate"), 0);
 
-            char ar_buf[16] = {0};
-            json_str(stream_buf, "AspectRatio", ar_buf, sizeof(ar_buf));
+            const char *ar_buf = json_as_str(json_find(doc, stream, "AspectRatio"), "");
             int ar_w = 0, ar_h = 0;
             if (ar_buf[0] && sscanf(ar_buf, "%d:%d", &ar_w, &ar_h) == 2 && ar_h > 0)
                 it->source_aspect = (double)ar_w / (double)ar_h;
         }
-
-        p = end + 1;
     }
 }
 
-/* Parses a {"Items":[ ... ]} BaseItemDtoQueryResult buffer into out[]. */
-static int parse_item_list(const char *buf, JfItem *out, int max)
+/* Parses a {"Items":[ ... ]} BaseItemDtoQueryResult into out[]. */
+static int parse_item_list(const JsonDoc *doc, JfItem *out, int max)
 {
+    const JsonNode *items = json_find(doc, NULL, "Items");
+    if (!items) return 0;
+
     int count = 0;
-    const char *p = strstr(buf, "\"Items\":[");
-    if (!p) return 0;
-    p = strchr(p, '[');
-    if (!p) return 0;
-    p++;
-
-    while (count < max) {
-        while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t' || *p == ',') p++;
-        if (*p != '{') break;
-        const char *end = json_find_obj_end(p);
-        if (!end) break;
-
-        int len = (int)(end - p + 1);
-        if (len > JF_ITEM_BUF - 1) len = JF_ITEM_BUF - 1;
-        char item_buf[JF_ITEM_BUF];
-        memcpy(item_buf, p, len);
-        item_buf[len] = '\0';
-
-        parse_item_fields(item_buf, &out[count]);
-
+    JSON_FOREACH(doc, items, item) {
+        if (count >= max) break;
+        parse_item_fields(doc, item, &out[count]);
         count++;
-        p = end + 1;
     }
     return count;
 }
 
 /* ── curl transport ──────────────────────────────────────────────────────── */
 
-/* Runs `curl -H "Authorization: ..." <url>`, captures stdout into buf.
- * Returns 1 on success (non-empty response), 0 on failure. */
-static int jf_get(const JfConfig *cfg, const char *path_and_query, char *buf, int buflen)
+/* Builds the Authorization header.
+ *
+ * The Token part is omitted entirely when there isn't one, rather than sent
+ * as Token="". That matters for exactly one call: QuickConnect/Initiate is
+ * unauthenticated by definition (it's how you GET a credential), but it does
+ * need the Client/Device/DeviceId fields, since those are what the server
+ * shows the user when asking them to approve the request. */
+static void jf_auth_header(const JfConfig *cfg, char *out, int outlen)
 {
+    /* Comma-space separated with Token last and omitted when absent — the
+     * same shape jellyfin-apiclient-python builds (http.py's
+     * _get_authenication_header), which is the reference for what real
+     * clients send. */
+    if (cfg->token[0])
+        snprintf(out, outlen,
+                 "Authorization: MediaBrowser " JF_CLIENT_HEADERS
+                 ", DeviceId=\"%s\", Token=\"%s\"",
+                 cfg->device_id, cfg->token);
+    else
+        snprintf(out, outlen,
+                 "Authorization: MediaBrowser " JF_CLIENT_HEADERS ", DeviceId=\"%s\"",
+                 cfg->device_id);
+}
+
+/* A fetched response and the parse tree over it. The tree's strings point
+ * into `text`, so the two have to be freed together — jf_response_free does
+ * both, and nothing should hold a JsonNode past that. */
+typedef struct {
+    JsonDoc doc;
+    char   *text;
+} JfResponse;
+
+static void jf_response_free(JfResponse *r)
+{
+    if (!r) return;
+    json_free(&r->doc);
+    free(r->text);
+    r->text = NULL;
+}
+
+/* Runs `curl -H "Authorization: ..." <url>` and returns its entire stdout as
+ * a NUL-terminated heap buffer (caller frees), or NULL on failure.
+ *
+ * Grows to fit rather than reading into a fixed buffer. The previous fixed
+ * 256KB cap was a silent data-loss bug: a response larger than the cap was
+ * cut mid-JSON and the old scanner simply stopped at the first malformed
+ * object, presenting a truncated library as a complete one. Now the response
+ * is always read in full, and if it somehow still can't be, parsing rejects
+ * it outright instead of half-accepting it. */
+static char *jf_request_alloc(const JfConfig *cfg, const char *method,
+                               const char *path_and_query, const char *body_file,
+                               int timeout_secs)
+{
+    char auth[320];
+    jf_auth_header(cfg, auth, sizeof(auth));
+
+    /* Assembled as optional fragments rather than branching over whole
+     * command lines — the four combinations of {GET, POST} × {body, no body}
+     * are otherwise four near-identical format strings to keep in step. */
+    char method_arg[24] = "";
+    if (method) snprintf(method_arg, sizeof(method_arg), "-X %s ", method);
+
+    char body_arg[128] = "";
+    if (body_file)
+        snprintf(body_arg, sizeof(body_arg),
+                 "-H 'Content-Type: application/json' --data-binary @%s ", body_file);
+
     char cmd[1024];
     snprintf(cmd, sizeof(cmd),
-        "curl -sfk --max-time 8 "
-        "-H 'Authorization: MediaBrowser " JF_CLIENT_HEADERS "Token=\"%s\"' "
-        "'%s%s' 2>/dev/null",
-        cfg->api_key, cfg->server, path_and_query);
+        "curl -sfk --max-time %d %s-H '%s' %s'%s%s' 2>/dev/null",
+        timeout_secs, method_arg, auth, body_arg, cfg->server, path_and_query);
 
     FILE *f = popen(cmd, "r");
-    if (!f) return 0;
-    size_t n = fread(buf, 1, (size_t)buflen - 1, f);
+    if (!f) return NULL;
+
+    size_t cap = 64 * 1024, len = 0;
+    char *buf = (char *)malloc(cap);
+    if (!buf) { pclose(f); return NULL; }
+
+    for (;;) {
+        if (len + 1 >= cap) {
+            size_t ncap = cap * 2;
+            char *grown = (char *)realloc(buf, ncap);
+            if (!grown) { free(buf); pclose(f); return NULL; }
+            buf = grown;
+            cap = ncap;
+        }
+        size_t got = fread(buf + len, 1, cap - len - 1, f);
+        if (got == 0) break;
+        len += got;
+    }
     pclose(f);
-    buf[n] = '\0';
-    return n > 0;
+
+    if (len == 0) { free(buf); return NULL; }
+    buf[len] = '\0';
+    return buf;
+}
+
+/* Fetch + parse in one step. Returns 1 on success, with *r owning both the
+ * text and the tree; 0 if the request failed or the response wasn't valid
+ * JSON (in which case *r is already cleaned up). */
+static int jf_fetch(const JfConfig *cfg, const char *path_and_query, JfResponse *r)
+{
+    memset(r, 0, sizeof(*r));
+    r->text = jf_request_alloc(cfg, NULL, path_and_query, NULL, 8);
+    if (!r->text) return 0;
+    if (!json_parse(&r->doc, r->text)) { jf_response_free(r); return 0; }
+    return 1;
 }
 
 /* Fire-and-forget POST with a JSON body (Sessions/Playing family). Body is
@@ -411,14 +523,17 @@ static void jf_post_json(const JfConfig *cfg, const char *path, const char *json
     fputs(json_body, f);
     fclose(f);
 
+    char auth[320];
+    jf_auth_header(cfg, auth, sizeof(auth));
+
     char cmd[768];
     snprintf(cmd, sizeof(cmd),
         "curl -sfk --max-time 5 -X POST "
-        "-H 'Authorization: MediaBrowser " JF_CLIENT_HEADERS "Token=\"%s\"' "
+        "-H '%s' "
         "-H 'Content-Type: application/json' "
         "--data-binary @%s "
         "'%s%s' >/dev/null 2>&1",
-        cfg->api_key, tmp_path, cfg->server, path);
+        auth, tmp_path, cfg->server, path);
     system(cmd);
     unlink(tmp_path);
 }
@@ -442,6 +557,20 @@ int jf_config_load(JfConfig *cfg)
     while (fgets(line, sizeof(line), f)) {
         line[strcspn(line, "\r\n")] = '\0';
         if (line[0] == '\0' || line[0] == '#') continue;
+
+        /* PAL/NTSC is recognised wherever it appears rather than strictly as
+         * the 4th line. The file is positional and blank lines are skipped,
+         * so with Quick Connect making the API key and username optional
+         * there was no way to write "no key, but NTSC" — the mode would slide
+         * up into the api_key slot and be read as a credential. Matching it
+         * by value instead keeps every combination expressible, and costs
+         * nothing: no server URL, key or username is ever the literal string
+         * "PAL" or "NTSC". */
+        if (!strcasecmp(line, "PAL") || !strcasecmp(line, "NTSC")) {
+            strncpy(cfg->tv_mode, line, sizeof(cfg->tv_mode) - 1);
+            continue;
+        }
+
         char *dst;
         int dstlen;
         switch (line_no) {
@@ -463,43 +592,286 @@ int jf_config_load(JfConfig *cfg)
     if (strcasecmp(cfg->tv_mode, "NTSC") != 0)
         strncpy(cfg->tv_mode, "PAL", sizeof(cfg->tv_mode) - 1);
 
-    return (cfg->server[0] && cfg->api_key[0] && cfg->username[0]);
+    /* An API key in the config file is used as-is; without one the caller
+     * falls back to a saved token, then to Quick Connect. */
+    strncpy(cfg->token, cfg->api_key, sizeof(cfg->token) - 1);
+
+    /* Only the server URL is required. api_key/username missing used to be a
+     * hard failure, which forced every user through the admin dashboard to
+     * mint a key — Quick Connect exists precisely so they don't have to. */
+    return cfg->server[0] != '\0';
+}
+
+int jf_has_credential(const JfConfig *cfg)
+{
+    return cfg && cfg->token[0] != '\0';
+}
+
+/* ── device identity ──────────────────────────────────────────────────────── */
+
+static const char *jf_device_paths[] = {
+    "/media/fat/misterfin/device.conf",
+    "./device.conf",
+    NULL
+};
+
+/* A random RFC-4122-shaped v4 GUID, which is what every other Jellyfin client
+ * reports. Seeded from /dev/urandom; rand() is the fallback for the
+ * essentially-impossible case of that being unavailable, and collisions there
+ * would only mean two installs sharing a device entry, not anything unsafe. */
+static void jf_generate_device_id(char *out, int outlen)
+{
+    unsigned char b[16];
+    int got = 0;
+
+    FILE *ur = fopen("/dev/urandom", "rb");
+    if (ur) {
+        got = (fread(b, 1, sizeof(b), ur) == sizeof(b));
+        fclose(ur);
+    }
+    if (!got) {
+        srand((unsigned)(time(NULL) ^ (getpid() << 16)));
+        for (size_t i = 0; i < sizeof(b); i++) b[i] = (unsigned char)(rand() & 0xFF);
+    }
+
+    b[6] = (unsigned char)((b[6] & 0x0F) | 0x40);   /* version 4 */
+    b[8] = (unsigned char)((b[8] & 0x3F) | 0x80);   /* variant 1 */
+
+    snprintf(out, outlen,
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             b[0], b[1], b[2],  b[3],  b[4],  b[5],  b[6],  b[7],
+             b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]);
+}
+
+void jf_device_id_init(JfConfig *cfg)
+{
+    FILE *f = NULL;
+    for (int i = 0; jf_device_paths[i] && !f; i++) f = fopen(jf_device_paths[i], "r");
+
+    if (f) {
+        char line[80] = {0};
+        if (fgets(line, sizeof(line), f)) {
+            line[strcspn(line, "\r\n")] = '\0';
+            /* Sanitised on the way in: it's read from disk, and it ends up
+             * inside a single-quoted shell argument. Generated ids only ever
+             * contain hex and dashes, so this is a no-op for them and only
+             * bites a hand-corrupted file. */
+            jf_sanitize_id(line, cfg->device_id, sizeof(cfg->device_id));
+        }
+        fclose(f);
+        if (cfg->device_id[0]) return;
+    }
+
+    jf_generate_device_id(cfg->device_id, sizeof(cfg->device_id));
+
+    /* Prefer the real install location; fall back to the working directory
+     * when it isn't there, same as the token file. */
+    const char *path = jf_device_paths[1];
+    FILE *probe = fopen("/media/fat/misterfin/jellyfin.conf", "r");
+    if (probe) { fclose(probe); path = jf_device_paths[0]; }
+
+    FILE *w = fopen(path, "w");
+    if (w) { fprintf(w, "%s\n", cfg->device_id); fclose(w); }
+    /* A write failure is survivable — the id just won't persist, so the
+     * server sees a new device next launch. Not worth failing startup over. */
+}
+
+/* ── saved token ──────────────────────────────────────────────────────────── */
+
+/* Written next to jellyfin.conf, with the desktop fallback the config loader
+ * uses so off-hardware runs don't try to write to /media/fat. Two lines:
+ * access token, then user id — the id is stored rather than re-resolved
+ * because /Users needs elevated access that a plain user token doesn't have. */
+static const char *jf_token_paths[] = {
+    "/media/fat/misterfin/token.conf",
+    "./token.conf",
+    NULL
+};
+
+static const char *jf_token_writable_path(void)
+{
+    /* Prefer the real install location, but fall back to the working
+     * directory when it isn't there (desktop runs). */
+    FILE *probe = fopen("/media/fat/misterfin/jellyfin.conf", "r");
+    if (probe) { fclose(probe); return jf_token_paths[0]; }
+    return jf_token_paths[1];
+}
+
+int jf_token_save(const JfConfig *cfg)
+{
+    if (!cfg->token[0]) return 0;
+    const char *path = jf_token_writable_path();
+    FILE *f = fopen(path, "w");
+    if (!f) return 0;
+    fprintf(f, "%s\n%s\n%s\n", cfg->token, cfg->user_id, cfg->username);
+    fclose(f);
+    return 1;
+}
+
+int jf_token_load(JfConfig *cfg)
+{
+    FILE *f = NULL;
+    for (int i = 0; jf_token_paths[i] && !f; i++) f = fopen(jf_token_paths[i], "r");
+    if (!f) return 0;
+
+    char token[192] = {0}, user_id[JF_ID_LEN] = {0}, username[64] = {0};
+    int ok = 0;
+    if (fgets(token, sizeof(token), f)) {
+        token[strcspn(token, "\r\n")] = '\0';
+        if (fgets(user_id, sizeof(user_id), f)) {
+            user_id[strcspn(user_id, "\r\n")] = '\0';
+            if (fgets(username, sizeof(username), f))
+                username[strcspn(username, "\r\n")] = '\0';
+            ok = token[0] && user_id[0];
+        }
+    }
+    fclose(f);
+    if (!ok) return 0;
+
+    strncpy(cfg->token,   token,   sizeof(cfg->token) - 1);
+    strncpy(cfg->user_id, user_id, sizeof(cfg->user_id) - 1);
+    if (username[0]) strncpy(cfg->username, username, sizeof(cfg->username) - 1);
+    return 1;
+}
+
+void jf_token_clear(void)
+{
+    for (int i = 0; jf_token_paths[i]; i++) unlink(jf_token_paths[i]);
+}
+
+/* ── Quick Connect ────────────────────────────────────────────────────────── */
+
+/* POST + parse, for the two Quick Connect calls that return a body.
+ * json_body may be NULL (Initiate takes no body at all). */
+static int jf_post_fetch(const JfConfig *cfg, const char *path,
+                          const char *json_body, JfResponse *r)
+{
+    memset(r, 0, sizeof(*r));
+
+    char tmp_path[64] = "";
+    if (json_body) {
+        snprintf(tmp_path, sizeof(tmp_path), "/tmp/misterfin_qc_%d.json", getpid());
+        FILE *f = fopen(tmp_path, "w");
+        if (!f) return 0;
+        fputs(json_body, f);
+        fclose(f);
+    }
+
+    r->text = jf_request_alloc(cfg, "POST", path, json_body ? tmp_path : NULL, 10);
+    if (json_body) unlink(tmp_path);
+
+    if (!r->text) return 0;
+    if (!json_parse(&r->doc, r->text)) { jf_response_free(r); return 0; }
+    return 1;
+}
+
+int jf_quick_connect_enabled(const JfConfig *cfg)
+{
+    /* Returns a bare `true`/`false` rather than an object — still valid JSON,
+     * so the parser handles it and the root node is the boolean itself. */
+    JfResponse r;
+    if (!jf_fetch(cfg, "/QuickConnect/Enabled", &r)) return 0;
+    int enabled = json_as_bool(json_root(&r.doc), 0);
+    jf_response_free(&r);
+    return enabled;
+}
+
+int jf_quick_connect_initiate(const JfConfig *cfg, JfQuickConnect *qc)
+{
+    memset(qc, 0, sizeof(*qc));
+
+    JfResponse r;
+    if (!jf_post_fetch(cfg, "/QuickConnect/Initiate", NULL, &r)) return 0;
+
+    json_copy_str(&r.doc, NULL, "Secret", qc->secret, sizeof(qc->secret));
+    json_copy_str(&r.doc, NULL, "Code",   qc->code,   sizeof(qc->code));
+    jf_response_free(&r);
+
+    return qc->secret[0] && qc->code[0];
+}
+
+int jf_quick_connect_poll(const JfConfig *cfg, const JfQuickConnect *qc)
+{
+    /* The secret is server-generated and goes into a URL, so it gets the same
+     * allowlist treatment as any other id from the server. */
+    char safe_secret[128];
+    jf_sanitize_id(qc->secret, safe_secret, sizeof(safe_secret));
+
+    char path[192];
+    snprintf(path, sizeof(path), "/QuickConnect/Connect?secret=%s", safe_secret);
+
+    JfResponse r;
+    /* A failed request here is ambiguous — 404 means the server has forgotten
+     * this request (expired or denied), but so does a dropped connection.
+     * Reported as -1 either way; the caller retries a couple of times before
+     * giving up, so a transient blip doesn't abandon a live request. */
+    if (!jf_fetch(cfg, path, &r)) return -1;
+
+    int authed = json_as_bool(json_find(&r.doc, NULL, "Authenticated"), 0);
+    jf_response_free(&r);
+    return authed ? 1 : 0;
+}
+
+int jf_quick_connect_authenticate(JfConfig *cfg, const JfQuickConnect *qc)
+{
+    char body[192];
+    snprintf(body, sizeof(body), "{\"Secret\":\"%s\"}", qc->secret);
+
+    JfResponse r;
+    if (!jf_post_fetch(cfg, "/Users/AuthenticateWithQuickConnect", body, &r)) return 0;
+
+    char token[sizeof(cfg->token)] = {0};
+    char user_id[JF_ID_LEN] = {0};
+    char username[64] = {0};
+    json_copy_str(&r.doc, NULL, "AccessToken",  token,    sizeof(token));
+    json_copy_str(&r.doc, NULL, "User.Id",      user_id,  sizeof(user_id));
+    json_copy_str(&r.doc, NULL, "User.Name",    username, sizeof(username));
+    jf_response_free(&r);
+
+    if (!token[0] || !user_id[0]) return 0;
+
+    strncpy(cfg->token,   token,   sizeof(cfg->token) - 1);
+    strncpy(cfg->user_id, user_id, sizeof(cfg->user_id) - 1);
+    /* Whoever approved the request IS the user — no /Users lookup needed, and
+     * no need for the username in the config file to match (or be there). */
+    if (username[0]) strncpy(cfg->username, username, sizeof(cfg->username) - 1);
+    return 1;
+}
+
+int jf_credential_works(const JfConfig *cfg)
+{
+    if (!jf_has_credential(cfg) || !cfg->user_id[0]) return 0;
+
+    /* UserViews is the smallest authenticated, user-scoped call available —
+     * it fails for a revoked token but doesn't need elevated access the way
+     * /Users does. */
+    char path[256];
+    snprintf(path, sizeof(path), "/UserViews?userId=%s", cfg->user_id);
+
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int ok = json_find(&r.doc, NULL, "Items") != NULL;
+    jf_response_free(&r);
+    return ok;
 }
 
 int jf_resolve_user_id(JfConfig *cfg)
 {
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, "/Users", buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return -1; }
+    JfResponse r;
+    if (!jf_fetch(cfg, "/Users", &r)) return -1;
 
-    const char *p = strchr(buf, '[');
-    if (!p) { pthread_mutex_unlock(&g_jf_mutex); return -1; }
-    p++;
-
-    while (1) {
-        while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t' || *p == ',') p++;
-        if (*p != '{') break;
-        const char *end = json_find_obj_end(p);
-        if (!end) break;
-
-        int len = (int)(end - p + 1);
-        char ubuf[512];
-        if (len > (int)sizeof(ubuf) - 1) len = (int)sizeof(ubuf) - 1;
-        memcpy(ubuf, p, len);
-        ubuf[len] = '\0';
-
-        char name[64] = {0};
-        json_str(ubuf, "Name", name, sizeof(name));
-        if (!strcasecmp(name, cfg->username)) {
-            json_str(ubuf, "Id", cfg->user_id, sizeof(cfg->user_id));
-            int ok = cfg->user_id[0] != '\0';
-            pthread_mutex_unlock(&g_jf_mutex);
-            return ok;
-        }
-        p = end + 1;
+    /* /Users returns a bare array, so the root node is what to iterate. */
+    int result = 0;
+    JSON_FOREACH(&r.doc, json_root(&r.doc), user) {
+        const char *name = json_as_str(json_find(&r.doc, user, "Name"), "");
+        if (strcasecmp(name, cfg->username) != 0) continue;
+        json_copy_str(&r.doc, user, "Id", cfg->user_id, sizeof(cfg->user_id));
+        result = cfg->user_id[0] != '\0';
+        break;
     }
-    pthread_mutex_unlock(&g_jf_mutex);
-    return 0;
+
+    jf_response_free(&r);
+    return result;
 }
 
 /* ── browsing ─────────────────────────────────────────────────────────────── */
@@ -509,12 +881,11 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max)
     char path[256];
     snprintf(path, sizeof(path), "/UserViews?userId=%s", cfg->user_id);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
     for (int i = 0; i < n; i++) out[i].type = JF_TYPE_FOLDER;
-    pthread_mutex_unlock(&g_jf_mutex);
+    jf_response_free(&r);
     return n;
 }
 
@@ -533,35 +904,54 @@ int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *i
             "/Items?userId=%s&ParentId=%s&Recursive=true&Limit=0",
             cfg->user_id, safe_parent);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return -1; }
-    int64_t count = 0;
-    int64_t result = json_int64(buf, "TotalRecordCount", &count) ? count : -1;
-    pthread_mutex_unlock(&g_jf_mutex);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return -1;
+    int64_t result = json_as_i64(json_find(&r.doc, NULL, "TotalRecordCount"), -1);
+    jf_response_free(&r);
     return result;
 }
 
-int jf_list_items(const JfConfig *cfg, const char *parent_id, JfItem *out, int max)
+/* Reads TotalRecordCount into *total_out (may be NULL), leaving it untouched
+ * if the server didn't send one — the caller then falls back to however many
+ * items actually arrived. */
+static void parse_total_count(const JsonDoc *doc, int64_t *total_out)
+{
+    if (!total_out) return;
+    const JsonNode *n = json_find(doc, NULL, "TotalRecordCount");
+    if (n && n->type == JSON_NUMBER) *total_out = n->i64;
+}
+
+int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
+                   JfItem *out, int max, int64_t *total_out)
 {
     char safe_parent[JF_ID_LEN];
     jf_sanitize_id(parent_id, safe_parent, sizeof(safe_parent));
+    if (start_index < 0) start_index = 0;
 
     /* ChildCount here (unlike on a top-level library view — see
      * jf_count_items's comment) is exactly what it sounds like for a
      * MusicAlbum: its own track count, confirmed against a real server. */
+    /* Overview is deliberately NOT requested here even though JfItem has a
+     * field for it: no browse-list row ever displays it (the info screen
+     * re-fetches via jf_get_item_details, which is where overview actually
+     * comes from), so it would be several times the JSON per row for nothing.
+     * Response size no longer risks losing data the way it once did — buffers
+     * grow to fit and a short read is now a hard parse failure — but there's
+     * still no reason to transfer and parse a paragraph per row that nothing
+     * reads. */
     char path[512];
     snprintf(path, sizeof(path),
         "/Items?userId=%s&ParentId=%s&SortBy=SortName&SortOrder=Ascending"
-        "&Fields=Overview,ProductionYear,RunTimeTicks,ChildCount&EnableUserData=true"
-        "&ImageTypeLimit=1&EnableImageTypes=Primary&Limit=%d",
-        cfg->user_id, safe_parent, max);
+        "&Fields=ProductionYear,RunTimeTicks,ChildCount,RecursiveItemCount"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+        cfg->user_id, safe_parent, start_index, max);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
-    pthread_mutex_unlock(&g_jf_mutex);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    parse_total_count(&r.doc, total_out);
+    jf_response_free(&r);
     return n;
 }
 
@@ -571,27 +961,29 @@ int jf_list_items_recursive(const JfConfig *cfg, const char *parent_id,
     char safe_parent[JF_ID_LEN];
     jf_sanitize_id(parent_id, safe_parent, sizeof(safe_parent));
 
+    /* No Overview here either — see jf_list_items. This one only ever feeds
+     * the carousel's background cover grid, which needs nothing but ids and
+     * image tags. */
     char path[560];
     if (item_type && item_type[0])
         snprintf(path, sizeof(path),
             "/Items?userId=%s&ParentId=%s&Recursive=true&IncludeItemTypes=%s"
             "&SortBy=SortName&SortOrder=Ascending"
-            "&Fields=Overview,ProductionYear,RunTimeTicks&EnableUserData=true"
+            "&Fields=ProductionYear,RunTimeTicks&EnableUserData=true"
             "&ImageTypeLimit=1&EnableImageTypes=Primary&Limit=%d",
             cfg->user_id, safe_parent, item_type, max);
     else
         snprintf(path, sizeof(path),
             "/Items?userId=%s&ParentId=%s&Recursive=true"
             "&SortBy=SortName&SortOrder=Ascending"
-            "&Fields=Overview,ProductionYear,RunTimeTicks&EnableUserData=true"
+            "&Fields=ProductionYear,RunTimeTicks&EnableUserData=true"
             "&ImageTypeLimit=1&EnableImageTypes=Primary&Limit=%d",
             cfg->user_id, safe_parent, max);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
-    pthread_mutex_unlock(&g_jf_mutex);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    jf_response_free(&r);
     return n;
 }
 
@@ -603,15 +995,60 @@ int jf_list_random_tracks(const JfConfig *cfg, const char *parent_id, JfItem *ou
     char path[512];
     snprintf(path, sizeof(path),
         "/Items?userId=%s&ParentId=%s&Recursive=true&IncludeItemTypes=Audio&SortBy=Random"
-        "&Fields=Overview,ProductionYear,RunTimeTicks&EnableUserData=true"
+        "&Fields=ProductionYear,RunTimeTicks&EnableUserData=true"
         "&ImageTypeLimit=1&EnableImageTypes=Primary&Limit=%d",
         cfg->user_id, safe_parent, max);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
-    pthread_mutex_unlock(&g_jf_mutex);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    jf_response_free(&r);
+    return n;
+}
+
+/* Shared field list for the two home rows. Both want enough to draw a browse
+ * row (year, runtime, watched/resume state, a cover) and nothing more. */
+#define JF_HOME_ROW_FIELDS \
+    "&Fields=ProductionYear,RunTimeTicks&EnableUserData=true" \
+    "&ImageTypeLimit=1&EnableImageTypes=Primary&EnableTotalRecordCount=true"
+
+int jf_list_resume(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out)
+{
+    /* MediaTypes=Video keeps half-listened music out of a row the user reads
+     * as "films and episodes I'm partway through". Jellyfin orders these by
+     * DatePlayed descending server-side, which is the order to preserve. */
+    char path[384];
+    snprintf(path, sizeof(path),
+        "/UserItems/Resume?userId=%s&MediaTypes=Video&Limit=%d" JF_HOME_ROW_FIELDS,
+        cfg->user_id, max);
+
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    parse_total_count(&r.doc, total_out);
+    jf_response_free(&r);
+    return n;
+}
+
+int jf_list_nextup(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out)
+{
+    /* enableResumable=false: a part-watched episode already appears under
+     * Continue Watching, and having the same episode in both rows makes the
+     * two look broken rather than complementary. Next Up is then strictly
+     * "what to start next". */
+    char path[384];
+    snprintf(path, sizeof(path),
+        "/Shows/NextUp?userId=%s&Limit=%d&enableResumable=false" JF_HOME_ROW_FIELDS,
+        cfg->user_id, max);
+
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    parse_total_count(&r.doc, total_out);
+    /* NextUp returns episodes by definition, but says so only via each item's
+     * own Type — set it explicitly for the same reason jf_list_episodes does. */
+    for (int i = 0; i < n; i++) out[i].type = JF_TYPE_EPISODE;
+    jf_response_free(&r);
     return n;
 }
 
@@ -626,14 +1063,16 @@ int jf_get_item_details(const JfConfig *cfg, const char *item_id, JfItem *out)
         "&EnableUserData=true&EnableImageTypes=Primary,Logo,Backdrop",
         safe_id, cfg->user_id);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
 
-    parse_item_fields(buf, out);
-    parse_cast(buf, out);
-    parse_media_streams(buf, out);
-    pthread_mutex_unlock(&g_jf_mutex);
+    /* A single-item fetch returns the item object itself as the root, so all
+     * three parsers are scoped to it rather than to a list element. */
+    const JsonNode *item = json_root(&r.doc);
+    parse_item_fields(&r.doc, item, out);
+    parse_cast(&r.doc, item, out);
+    parse_media_streams(&r.doc, item, out);
+    jf_response_free(&r);
     return 1;
 }
 
@@ -645,35 +1084,35 @@ int jf_list_seasons(const JfConfig *cfg, const char *series_id, JfItem *out, int
     char path[256];
     snprintf(path, sizeof(path), "/Shows/%s/Seasons?userId=%s", safe_series, cfg->user_id);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
     for (int i = 0; i < n; i++) out[i].type = JF_TYPE_SEASON;
-    pthread_mutex_unlock(&g_jf_mutex);
+    jf_response_free(&r);
     return n;
 }
 
 int jf_list_episodes(const JfConfig *cfg, const char *series_id, const char *season_id,
-                      JfItem *out, int max)
+                      int start_index, JfItem *out, int max, int64_t *total_out)
 {
     char safe_series[JF_ID_LEN], safe_season[JF_ID_LEN];
     jf_sanitize_id(series_id, safe_series, sizeof(safe_series));
     jf_sanitize_id(season_id, safe_season, sizeof(safe_season));
+    if (start_index < 0) start_index = 0;
 
-    char path[384];
+    char path[416];
     snprintf(path, sizeof(path),
         "/Shows/%s/Episodes?seasonId=%s&userId=%s"
-        "&Fields=Overview,RunTimeTicks&EnableUserData=true"
-        "&ImageTypeLimit=1&EnableImageTypes=Primary",
-        safe_series, safe_season, cfg->user_id);
+        "&Fields=RunTimeTicks&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+        safe_series, safe_season, cfg->user_id, start_index, max);
 
-    pthread_mutex_lock(&g_jf_mutex);
-    static char buf[JF_BUF_SIZE];
-    if (!jf_get(cfg, path, buf, sizeof(buf))) { pthread_mutex_unlock(&g_jf_mutex); return 0; }
-    int n = parse_item_list(buf, out, max);
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return 0;
+    int n = parse_item_list(&r.doc, out, max);
+    parse_total_count(&r.doc, total_out);
     for (int i = 0; i < n; i++) out[i].type = JF_TYPE_EPISODE;
-    pthread_mutex_unlock(&g_jf_mutex);
+    jf_response_free(&r);
     return n;
 }
 
@@ -729,6 +1168,7 @@ int jf_download_image(const JfConfig *cfg, const JfItem *item, const char *dest_
 int jf_stream_url(const JfConfig *cfg, const char *item_id,
                    const JfStreamProfile *profile, int64_t start_ticks,
                    const char *play_session_id, int burn_in_sub_index,
+                   int audio_stream_index,
                    char *out, int outlen)
 {
     char safe_id[JF_ID_LEN];
@@ -764,15 +1204,22 @@ int jf_stream_url(const JfConfig *cfg, const char *item_id,
         snprintf(sub_params, sizeof(sub_params),
                  "&subtitleStreamIndex=%d&subtitleMethod=Encode", burn_in_sub_index);
 
+    /* Omitted entirely rather than guessed when no explicit track is wanted,
+     * so the server applies the source's own default selection. */
+    char audio_params[32] = "";
+    if (audio_stream_index >= 0)
+        snprintf(audio_params, sizeof(audio_params),
+                 "&audioStreamIndex=%d", audio_stream_index);
+
     snprintf(out, outlen,
         "%s/Videos/%s/stream?static=false&videoCodec=mpeg2video&container=ts"
         "&audioCodec=mp3&audioChannels=2"
         "&maxWidth=%d&maxHeight=%d&videoBitRate=%d"
-        "&startTimeTicks=%lld&playSessionId=%s%s&ApiKey=%s",
+        "&startTimeTicks=%lld&playSessionId=%s%s%s&ApiKey=%s",
         cfg->server, safe_id,
         profile->max_width, profile->max_height, profile->video_bitrate,
         (long long)(start_ticks > 0 ? start_ticks : 0),
-        safe_session, sub_params, cfg->api_key);
+        safe_session, sub_params, audio_params, cfg->token);
     return 1;
 }
 
@@ -802,7 +1249,7 @@ int jf_audio_stream_url(const JfConfig *cfg, const char *item_id,
     jf_sanitize_id(play_session_id, safe_session, sizeof(safe_session));
     snprintf(out, outlen,
         "%s/Audio/%s/stream?static=true&playSessionId=%s&ApiKey=%s",
-        cfg->server, safe_id, safe_session, cfg->api_key);
+        cfg->server, safe_id, safe_session, cfg->token);
     return 1;
 }
 
@@ -816,7 +1263,7 @@ int jf_download_subtitle(const JfConfig *cfg, const char *item_id,
 
     char url[384];
     snprintf(url, sizeof(url), "%s/Videos/%s/%s/Subtitles/%d/Stream.srt?ApiKey=%s",
-              cfg->server, safe_id, safe_msid, sub_index, cfg->api_key);
+              cfg->server, safe_id, safe_msid, sub_index, cfg->token);
 
     char cmd[768];
     snprintf(cmd, sizeof(cmd),

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -605,6 +605,10 @@ static void jf_post_json(const JfConfig *cfg, const char *path, const char *json
 int jf_config_load(JfConfig *cfg)
 {
     memset(cfg, 0, sizeof(*cfg));
+    cfg->profile_width   = JF_PROFILE_DEFAULT_W;
+    cfg->profile_height  = JF_PROFILE_DEFAULT_H;
+    cfg->profile_bitrate = JF_PROFILE_DEFAULT_RATE;
+
     const char *paths[] = {
         "/media/fat/misterfin/jellyfin.conf",
         "./jellyfin.conf",
@@ -619,6 +623,29 @@ int jf_config_load(JfConfig *cfg)
     while (fgets(line, sizeof(line), f)) {
         line[strcspn(line, "\r\n")] = '\0';
         if (line[0] == '\0' || line[0] == '#') continue;
+
+        /* An optional transcode profile, "WxH" or "WxH@BITRATE" (e.g.
+         * "640x480@12000000"). Matched by shape rather than by position for
+         * the same reason as PAL/NTSC below — and the shape is unambiguous:
+         * a server URL contains "://", and no API key or username is two
+         * integers joined by an 'x'. sscanf's %n confirms the whole line was
+         * consumed, so "480x270junk" is not silently accepted. */
+        {
+            int w = 0, h = 0, rate = 0, used = 0;
+            if ((sscanf(line, "%dx%d@%d%n", &w, &h, &rate, &used) == 3 && !line[used]) ||
+                (sscanf(line, "%dx%d%n", &w, &h, &used) == 2 && !line[used])) {
+                if (w >= JF_PROFILE_MIN_W && w <= JF_PROFILE_MAX_W &&
+                    h >= JF_PROFILE_MIN_H && h <= JF_PROFILE_MAX_H) {
+                    cfg->profile_width  = w;
+                    cfg->profile_height = h;
+                    if (rate >= JF_PROFILE_MIN_RATE && rate <= JF_PROFILE_MAX_RATE)
+                        cfg->profile_bitrate = rate;
+                }
+                /* Consumed either way — a malformed profile line must not
+                 * fall through and be read as an API key. */
+                continue;
+            }
+        }
 
         /* PAL/NTSC is recognised wherever it appears rather than strictly as
          * the 4th line. The file is positional and blank lines are skipped,

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -6,6 +6,9 @@
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/wait.h>
 #include <time.h>
 
 #ifndef APP_VERSION
@@ -441,15 +444,92 @@ static void jf_response_free(JfResponse *r)
     r->text = NULL;
 }
 
-/* Runs `curl -H "Authorization: ..." <url>` and returns its entire stdout as
- * a NUL-terminated heap buffer (caller frees), or NULL on failure.
+/* Runs curl with an explicit argument vector and NO SHELL, optionally
+ * capturing stdout into a NUL-terminated heap buffer (caller frees).
+ * Returns the buffer when capture is set and something was read, else NULL;
+ * *exit_ok (may be NULL) reports whether curl itself exited 0.
  *
- * Grows to fit rather than reading into a fixed buffer. The previous fixed
- * 256KB cap was a silent data-loss bug: a response larger than the cap was
- * cut mid-JSON and the old scanner simply stopped at the first malformed
- * object, presenting a truncated library as a complete one. Now the response
- * is always read in full, and if it somehow still can't be, parsing rejects
- * it outright instead of half-accepting it. */
+ * The absence of a shell is the entire point. Every one of these arguments —
+ * the Authorization header, the URL — carries data that ultimately came from
+ * the server, and with popen()/system() that data was being parsed by /bin/sh.
+ * A hostile server answering Quick Connect with
+ *     {"AccessToken":"x' ; <command> ; '"}
+ * got that command executed as root, on every launch thereafter, because the
+ * token is saved to disk. Confirmed by reproduction, not theory. Note the
+ * escape: Jellyfin encodes an apostrophe as ', so decoding escapes
+ * correctly (which this client now does) is what turns a quoted string into
+ * a quote-breaking one. execvp takes argv straight to the kernel — there is
+ * no parser between us and exec, so no quoting to escape from.
+ *
+ * The capture path grows to fit rather than reading into a fixed buffer: the
+ * old 256KB cap silently truncated large responses mid-JSON. */
+static char *jf_curl_run(char *const argv[], int capture, int *exit_ok)
+{
+    if (exit_ok) *exit_ok = 0;
+
+    int pfd[2];
+    if (capture && pipe(pfd) != 0) return NULL;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        if (capture) { close(pfd[0]); close(pfd[1]); }
+        return NULL;
+    }
+
+    if (pid == 0) {
+        if (capture) {
+            dup2(pfd[1], STDOUT_FILENO);
+            close(pfd[0]);
+            close(pfd[1]);
+        }
+        /* curl's own diagnostics would otherwise land in the middle of the
+         * framebuffer UI on the console. */
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDERR_FILENO);
+            if (!capture) dup2(devnull, STDOUT_FILENO);
+            close(devnull);
+        }
+        execvp("curl", argv);
+        _exit(127);
+    }
+
+    char *buf = NULL;
+    size_t len = 0;
+    if (capture) {
+        close(pfd[1]);
+        size_t cap = 64 * 1024;
+        buf = (char *)malloc(cap);
+        if (buf) {
+            for (;;) {
+                if (len + 1 >= cap) {
+                    size_t ncap = cap * 2;
+                    char *grown = (char *)realloc(buf, ncap);
+                    if (!grown) { free(buf); buf = NULL; len = 0; break; }
+                    buf = grown;
+                    cap = ncap;
+                }
+                ssize_t got = read(pfd[0], buf + len, cap - len - 1);
+                if (got <= 0) break;
+                len += (size_t)got;
+            }
+        }
+        /* Drain anything left so curl never blocks on a full pipe while we're
+         * waiting for it to exit. */
+        if (!buf) { char sink[4096]; while (read(pfd[0], sink, sizeof(sink)) > 0) {} }
+        close(pfd[0]);
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+    if (exit_ok) *exit_ok = (WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+    if (!capture) { free(buf); return NULL; }
+    if (!buf || len == 0) { free(buf); return NULL; }
+    buf[len] = '\0';
+    return buf;
+}
+
 static char *jf_request_alloc(const JfConfig *cfg, const char *method,
                                const char *path_and_query, const char *body_file,
                                int timeout_secs)
@@ -457,46 +537,36 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
     char auth[320];
     jf_auth_header(cfg, auth, sizeof(auth));
 
-    /* Assembled as optional fragments rather than branching over whole
-     * command lines — the four combinations of {GET, POST} × {body, no body}
-     * are otherwise four near-identical format strings to keep in step. */
-    char method_arg[24] = "";
-    if (method) snprintf(method_arg, sizeof(method_arg), "-X %s ", method);
+    char timeout[16];
+    snprintf(timeout, sizeof(timeout), "%d", timeout_secs);
 
-    char body_arg[128] = "";
-    if (body_file)
-        snprintf(body_arg, sizeof(body_arg),
-                 "-H 'Content-Type: application/json' --data-binary @%s ", body_file);
+    char url[1024];
+    snprintf(url, sizeof(url), "%s%s", cfg->server, path_and_query);
 
-    char cmd[1024];
-    snprintf(cmd, sizeof(cmd),
-        "curl -sfk --max-time %d %s-H '%s' %s'%s%s' 2>/dev/null",
-        timeout_secs, method_arg, auth, body_arg, cfg->server, path_and_query);
+    char body_arg[128];
+    if (body_file) snprintf(body_arg, sizeof(body_arg), "@%s", body_file);
 
-    FILE *f = popen(cmd, "r");
-    if (!f) return NULL;
-
-    size_t cap = 64 * 1024, len = 0;
-    char *buf = (char *)malloc(cap);
-    if (!buf) { pclose(f); return NULL; }
-
-    for (;;) {
-        if (len + 1 >= cap) {
-            size_t ncap = cap * 2;
-            char *grown = (char *)realloc(buf, ncap);
-            if (!grown) { free(buf); pclose(f); return NULL; }
-            buf = grown;
-            cap = ncap;
-        }
-        size_t got = fread(buf + len, 1, cap - len - 1, f);
-        if (got == 0) break;
-        len += got;
+    /* Built as a plain argv. Each element reaches curl exactly as written,
+     * with no quoting, escaping or word splitting anywhere in between. */
+    const char *argv[20];
+    int n = 0;
+    argv[n++] = "curl";
+    argv[n++] = "-sfk";
+    argv[n++] = "--max-time";
+    argv[n++] = timeout;
+    if (method) { argv[n++] = "-X"; argv[n++] = method; }
+    argv[n++] = "-H";
+    argv[n++] = auth;
+    if (body_file) {
+        argv[n++] = "-H";
+        argv[n++] = "Content-Type: application/json";
+        argv[n++] = "--data-binary";
+        argv[n++] = body_arg;
     }
-    pclose(f);
+    argv[n++] = url;
+    argv[n]   = NULL;
 
-    if (len == 0) { free(buf); return NULL; }
-    buf[len] = '\0';
-    return buf;
+    return jf_curl_run((char *const *)argv, 1, NULL);
 }
 
 /* Fetch + parse in one step. Returns 1 on success, with *r owning both the
@@ -523,18 +593,10 @@ static void jf_post_json(const JfConfig *cfg, const char *path, const char *json
     fputs(json_body, f);
     fclose(f);
 
-    char auth[320];
-    jf_auth_header(cfg, auth, sizeof(auth));
-
-    char cmd[768];
-    snprintf(cmd, sizeof(cmd),
-        "curl -sfk --max-time 5 -X POST "
-        "-H '%s' "
-        "-H 'Content-Type: application/json' "
-        "--data-binary @%s "
-        "'%s%s' >/dev/null 2>&1",
-        auth, tmp_path, cfg->server, path);
-    system(cmd);
+    /* Reuses the same no-shell path as every other request — see
+     * jf_curl_run. The response is discarded, but the arguments still carry
+     * the server-issued token. */
+    free(jf_request_alloc(cfg, "POST", path, tmp_path, 5));
     unlink(tmp_path);
 }
 
@@ -605,6 +667,16 @@ int jf_config_load(JfConfig *cfg)
 int jf_has_credential(const JfConfig *cfg)
 {
     return cfg && cfg->token[0] != '\0';
+}
+
+/* Rejects control characters (and DEL) anywhere in a credential. Empty is
+ * fine — callers check that separately where it matters. */
+static int jf_credential_is_sane(const char *s)
+{
+    if (!s) return 0;
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+        if (*p < 0x20 || *p == 0x7F) return 0;
+    return 1;
 }
 
 /* ── device identity ──────────────────────────────────────────────────────── */
@@ -830,6 +902,18 @@ int jf_quick_connect_authenticate(JfConfig *cfg, const JfQuickConnect *qc)
 
     if (!token[0] || !user_id[0]) return 0;
 
+    /* A credential is opaque to us, so there's nothing to validate about its
+     * content — except that it must not contain control characters. token.conf
+     * is line-oriented, and a newline inside the token (which the server can
+     * send as
+, and which this client now decodes faithfully) would
+     * write a file that reloads as a different, truncated credential: a
+     * permanent self-inflicted lockout. Rejecting outright beats storing
+     * something that silently means something else. */
+    if (!jf_credential_is_sane(token) || !jf_credential_is_sane(user_id) ||
+        !jf_credential_is_sane(username))
+        return 0;
+
     strncpy(cfg->token,   token,   sizeof(cfg->token) - 1);
     strncpy(cfg->user_id, user_id, sizeof(cfg->user_id) - 1);
     /* Whoever approved the request IS the user — no /Users lookup needed, and
@@ -948,7 +1032,7 @@ int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
         cfg->user_id, safe_parent, start_index, max);
 
     JfResponse r;
-    if (!jf_fetch(cfg, path, &r)) return 0;
+    if (!jf_fetch(cfg, path, &r)) return -1;   /* transport/parse failure, not an empty page */
     int n = parse_item_list(&r.doc, out, max);
     parse_total_count(&r.doc, total_out);
     jf_response_free(&r);
@@ -1023,7 +1107,7 @@ int jf_list_resume(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out
         cfg->user_id, max);
 
     JfResponse r;
-    if (!jf_fetch(cfg, path, &r)) return 0;
+    if (!jf_fetch(cfg, path, &r)) return -1;   /* transport/parse failure, not an empty page */
     int n = parse_item_list(&r.doc, out, max);
     parse_total_count(&r.doc, total_out);
     jf_response_free(&r);
@@ -1042,7 +1126,7 @@ int jf_list_nextup(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out
         cfg->user_id, max);
 
     JfResponse r;
-    if (!jf_fetch(cfg, path, &r)) return 0;
+    if (!jf_fetch(cfg, path, &r)) return -1;   /* see jf_list_items */
     int n = parse_item_list(&r.doc, out, max);
     parse_total_count(&r.doc, total_out);
     /* NextUp returns episodes by definition, but says so only via each item's
@@ -1108,7 +1192,7 @@ int jf_list_episodes(const JfConfig *cfg, const char *series_id, const char *sea
         safe_series, safe_season, cfg->user_id, start_index, max);
 
     JfResponse r;
-    if (!jf_fetch(cfg, path, &r)) return 0;
+    if (!jf_fetch(cfg, path, &r)) return -1;   /* see jf_list_items */
     int n = parse_item_list(&r.doc, out, max);
     parse_total_count(&r.doc, total_out);
     for (int i = 0; i < n; i++) out[i].type = JF_TYPE_EPISODE;
@@ -1147,10 +1231,13 @@ int jf_download_item_image(const JfConfig *cfg, const char *item_id, const char 
     char url[512];
     if (!jf_item_image_url(cfg, item_id, image_type, tag, max_width, url, sizeof(url))) return 0;
 
-    char cmd[768];
-    snprintf(cmd, sizeof(cmd),
-        "curl -sfLk --max-time 15 '%s' -o '%s' 2>/dev/null", url, dest_path);
-    return system(cmd) == 0;
+    /* No shell — see jf_curl_run. The URL embeds an image tag that came
+     * from server JSON. */
+    const char *argv[] = { "curl", "-sfLk", "--max-time", "15",
+                           url, "-o", dest_path, NULL };
+    int ok = 0;
+    jf_curl_run((char *const *)argv, 0, &ok);
+    return ok;
 }
 
 int jf_image_url(const JfConfig *cfg, const JfItem *item, char *out, int outlen)
@@ -1261,14 +1348,18 @@ int jf_download_subtitle(const JfConfig *cfg, const char *item_id,
     jf_sanitize_id(item_id, safe_id, sizeof(safe_id));
     jf_sanitize_id(media_source_id, safe_msid, sizeof(safe_msid));
 
-    char url[384];
+    /* Sized for a full server URL plus a 191-byte token: 384 bytes could
+     * truncate the ApiKey, which showed up as subtitles silently failing to
+     * load rather than as any visible error. */
+    char url[768];
     snprintf(url, sizeof(url), "%s/Videos/%s/%s/Subtitles/%d/Stream.srt?ApiKey=%s",
               cfg->server, safe_id, safe_msid, sub_index, cfg->token);
 
-    char cmd[768];
-    snprintf(cmd, sizeof(cmd),
-        "curl -sfLk --max-time 15 '%s' -o '%s' 2>/dev/null", url, dest_path);
-    return system(cmd) == 0;
+    const char *argv[] = { "curl", "-sfLk", "--max-time", "15",
+                           url, "-o", dest_path, NULL };
+    int ok = 0;
+    jf_curl_run((char *const *)argv, 0, &ok);
+    return ok;
 }
 
 void jf_make_play_session_id(char *out, int outlen)

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -17,6 +17,10 @@
  * scrolled to. The client keeps ONE such page loaded at a time and slides it
  * (see jf_list_items' start_index). */
 #define JF_PAGE_SIZE   128
+/* Upper bound applied to a server-reported TotalRecordCount before it reaches
+ * the client's window arithmetic. Far beyond any real library, but finite:
+ * the alternative is trusting a remote integer not to overflow int math. */
+#define JF_MAX_TOTAL_ITEMS 100000000
 #define JF_ID_LEN      40
 #define JF_NAME_LEN    256
 #define JF_OVERVIEW_LEN 1024
@@ -110,6 +114,12 @@ typedef struct {
     char       collection_type[16];  /* CollectionType — "movies"/"tvshows"/"music"/...,
                                        * library views only (jf_list_views), empty otherwise */
     JfItemType type;
+    /* Non-zero only for the client's own synthetic home-screen entries (see
+     * JF_SYNTH_*). parse_item_fields memsets, so anything that came from the
+     * server always reads 0 — which is the point: identifying these by id
+     * alone let a hostile server return an item with that id and shadow a
+     * real library into being unreachable. */
+    int        synthetic;
     int64_t    runtime_ticks;          /* RunTimeTicks, 0 if unknown */
     int        child_count;            /* ChildCount — track count for a MusicAlbum
                                          * (jf_list_items only requests this field);
@@ -299,7 +309,12 @@ int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *i
  * start_index — one window of a potentially much longer list. Writes the
  * server's untruncated TotalRecordCount to *total_out (may be NULL), which
  * is what lets the caller know there's more to page to; without it a client
- * cannot tell "that's the whole library" from "that's all that fit". */
+ * cannot tell "that's the whole library" from "that's all that fit".
+ *
+ * Returns the number of items, or -1 if the request itself failed. That's a
+ * distinct value from 0 on purpose: a caller sliding a window has to roll
+ * back to the page it already had rather than commit an empty one, and an
+ * empty page is a legitimate answer it must not confuse with a dead network. */
 int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
                    JfItem *out, int max, int64_t *total_out);
 
@@ -325,6 +340,11 @@ int jf_list_random_tracks(const JfConfig *cfg, const char *parent_id, JfItem *ou
  * filenames). */
 #define JF_VIEW_RESUME  "misterfin-resume"
 #define JF_VIEW_NEXTUP  "misterfin-nextup"
+
+/* Values for JfItem.synthetic. The ids above remain as grid-cache keys; these
+ * are what the code actually branches on. */
+#define JF_SYNTH_RESUME 1
+#define JF_SYNTH_NEXTUP 2
 
 /* Partly-watched items across the whole library, most recently played first
  * (Jellyfin's "Continue Watching"). Returns movies and episodes together.

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -8,13 +8,27 @@
  * rather than guessed — see README "Known limitations". */
 
 #define JF_MAX_ITEMS   256
+/* How many items one browse request asks for. Smaller than JF_MAX_ITEMS on
+ * purpose: the whole response has to fit in jf_get's fixed buffer, and at
+ * roughly 700 bytes of JSON per row a full 256 would land uncomfortably
+ * close to it. Anything past a truncation point is silently lost (the parser
+ * just stops at the first malformed object), so the margin matters more than
+ * the round-trip count — and a library only pays for the pages actually
+ * scrolled to. The client keeps ONE such page loaded at a time and slides it
+ * (see jf_list_items' start_index). */
+#define JF_PAGE_SIZE   128
 #define JF_ID_LEN      40
 #define JF_NAME_LEN    256
 #define JF_OVERVIEW_LEN 1024
 #define JF_PERSON_NAME_LEN 64
 #define JF_MAX_CAST    8
 #define JF_MAX_SUBS    8
-#define JF_SUB_LABEL_LEN 48
+#define JF_MAX_AUDIO   8
+/* Long enough for a fully-composed DisplayTitle — "English - Hearing
+ * Impaired - Default - SUBRIP - External" is 55 characters. Storing the whole
+ * thing means any shortening happens at draw time, where it's clipped to the
+ * actual pixel width available, rather than being cut blindly here. */
+#define JF_SUB_LABEL_LEN 72
 
 typedef enum {
     JF_TYPE_FOLDER,   /* library view / generic folder */
@@ -37,10 +51,29 @@ typedef struct {
 
 typedef struct {
     int  index;                        /* MediaStreams[].Index — pass as subtitleStreamIndex */
-    char label[JF_SUB_LABEL_LEN];       /* Language if set, else DisplayTitle */
+    char label[JF_SUB_LABEL_LEN];       /* DisplayTitle if set, else Language. The server
+                                         * builds DisplayTitle as the track's own Title
+                                         * followed by whichever of Hearing Impaired /
+                                         * Default / Forced / codec / External apply —
+                                         * which is what separates a dialogue track from a
+                                         * signs-and-songs one when both are tagged "eng" */
     char codec[16];                    /* MediaStreams[].Codec, e.g. "subrip", "ass",
                                          * "pgssub", "dvdsub" — see jf_subtitle_is_text() */
+    int  is_forced;                    /* MediaStreams[].IsForced */
+    int  is_default;                   /* MediaStreams[].IsDefault */
 } JfSubtitle;
+
+typedef struct {
+    int  index;                        /* MediaStreams[].Index — pass as audioStreamIndex */
+    char label[JF_SUB_LABEL_LEN];       /* DisplayTitle if set, else Language — the server
+                                         * composes DisplayTitle as e.g. "English - Dolby
+                                         * Digital 5.1 - Default", which is what actually
+                                         * distinguishes a commentary from the main mix
+                                         * when both are tagged the same language */
+    char codec[16];                    /* "ac3", "aac", "dts", ... */
+    int  channels;                     /* 2, 6, ... — 0 if unreported */
+    int  is_default;                   /* MediaStreams[].IsDefault */
+} JfAudioTrack;
 
 typedef struct {
     char       id[JF_ID_LEN];
@@ -69,6 +102,11 @@ typedef struct {
     char       year[8];
     char       album[JF_NAME_LEN];   /* Album — tracks only, empty otherwise */
     char       artist[JF_NAME_LEN];  /* AlbumArtist — tracks only, empty otherwise */
+    /* SeriesName — episodes only, empty otherwise. Redundant inside a season's
+     * own episode list (the frame title already says which show it is), but
+     * essential for the Continue Watching / Next Up rows, where an episode
+     * called "Episode 03" is otherwise unidentifiable. */
+    char       series_name[JF_NAME_LEN];
     char       collection_type[16];  /* CollectionType — "movies"/"tvshows"/"music"/...,
                                        * library views only (jf_list_views), empty otherwise */
     JfItemType type;
@@ -76,14 +114,36 @@ typedef struct {
     int        child_count;            /* ChildCount — track count for a MusicAlbum
                                          * (jf_list_items only requests this field);
                                          * 0/unset for every other item type. */
+    /* RecursiveItemCount — every non-folder, non-virtual descendant, i.e.
+     * the episode count for a Series (confirmed against the server's own
+     * count query, which filters exactly that way, so unaired/missing
+     * episodes are excluded — what you'd actually want to read on a row).
+     * Requires Fields=RecursiveItemCount AND EnableUserData=true: the
+     * server computes it inside its user-data block, batched across the
+     * whole result set in one query. That batching is the entire point of
+     * using it — the client used to issue one extra recursive count request
+     * PER SERIES ROW to get this same number, so a 200-series library meant
+     * 200 sequential curl invocations before the list could draw. 0 if not
+     * requested or not applicable. */
+    int        recursive_item_count;
     int64_t    resume_ticks;           /* UserData.PlaybackPositionTicks */
     int        played;                 /* UserData.Played */
     int        index_number;           /* episode/season number, -1 if n/a */
+    int        parent_index_number;    /* ParentIndexNumber — season number for an
+                                         * episode, -1 if n/a. With index_number this
+                                         * gives the "S1E03" an out-of-context episode
+                                         * row needs. */
     double     community_rating;       /* CommunityRating, e.g. 7.4 — 0 if unset/not fetched */
     JfPerson   cast[JF_MAX_CAST];       /* Actors only, empty unless fetched via jf_get_item_details */
     int        cast_count;
     JfSubtitle subs[JF_MAX_SUBS];       /* empty unless fetched via jf_get_item_details */
     int        sub_count;
+    /* Selectable audio tracks, same lifecycle as subs[]. Unlike subtitles
+     * these can't be switched client-side: the server transcodes exactly one
+     * audio stream into the delivered container, so changing tracks means
+     * rebuilding the stream URL and restarting playback. */
+    JfAudioTrack audio[JF_MAX_AUDIO];
+    int          audio_count;
     /* Source (original file) video specs — from MediaStreams, empty unless
      * fetched via jf_get_item_details. What's actually streamed to the
      * device is different (see JfStreamProfile) — this is for display only. */
@@ -101,18 +161,112 @@ typedef struct {
 
 typedef struct {
     char server[256];   /* e.g. http://192.168.2.10:8096 (no trailing slash) */
-    char api_key[64];
+    char api_key[64];   /* config line 2, may be empty — see jf_config_load */
     char username[64];  /* config line 3 — resolved to user_id via jf_resolve_user_id() */
     char user_id[JF_ID_LEN];   /* empty until resolved; everything else needs this, not username */
     char tv_mode[8];     /* "PAL" (default) or "NTSC" — 4th, optional config line */
+    /* The credential actually sent with every request, as both the
+     * Authorization header's Token and the ApiKey query parameter on media
+     * URLs. Either an API key copied from api_key, or an access token earned
+     * through Quick Connect — the server treats the two identically, so
+     * nothing downstream needs to know which it got. Empty means
+     * unauthenticated, which is valid for exactly one thing: starting a Quick
+     * Connect request. */
+    char token[192];
+    /* Identifies this install to the server. Generated once and persisted —
+     * NOT a compile-time constant shared by every copy of the app, which it
+     * used to be.
+     *
+     * That mattered the moment Quick Connect arrived. Jellyfin's
+     * GetAuthorizationToken logs out every existing session matching
+     * (DeviceId, UserId) whenever a new one authenticates, so two MiSTers
+     * signed in as the same user and reporting the same DeviceId would
+     * silently revoke each other's token on every launch — and since a
+     * revoked token sends this client back through Quick Connect, they'd
+     * take turns kicking one another out indefinitely. The API key path
+     * creates no session, which is why this was harmless before. */
+    char device_id[64];
 } JfConfig;
+
+/* One in-flight Quick Connect request. */
+typedef struct {
+    char secret[128];   /* the client's half — never shown to the user */
+    char code[16];      /* the short code the user types into Jellyfin */
+} JfQuickConnect;
+
+/* Folds a UTF-8 string down to the ASCII subset the on-screen bitmap font can
+ * draw (accents stripped, smart quotes and dashes normalised, anything with
+ * no ASCII form collapsed to a single '?'). Every server string that reaches
+ * the screen already goes through this on the way into a JfItem; it's exposed
+ * for callers that get text from somewhere else, e.g. downloaded subtitles. */
+void jf_text_to_display(const char *utf8, char *out, int outlen);
 
 /* Loads /media/fat/misterfin/jellyfin.conf (falls back to ./jellyfin.conf for
  * desktop testing). 4 lines: server, api_key, username, tv_mode (optional,
- * defaults to PAL). Returns 1 on success, 0 if missing/incomplete.
- * cfg->user_id is NOT populated here — call jf_resolve_user_id() once at
- * startup (it needs a network round-trip). */
+ * defaults to PAL). Returns 1 if there's at least a server URL, 0 otherwise.
+ *
+ * Only the server URL is genuinely required now. An empty api_key/username is
+ * no longer a failure — it means "authenticate with Quick Connect instead",
+ * which is the point: obtaining an API key needs the admin dashboard, so
+ * requiring one made every user an admin of their own server or dependent on
+ * someone who is. cfg->user_id is NOT populated here; see jf_resolve_user_id
+ * or jf_quick_connect_authenticate. */
 int jf_config_load(JfConfig *cfg);
+
+/* Whether cfg carries a usable credential at all (an API key from the config
+ * file, or a token loaded/earned at runtime). */
+int jf_has_credential(const JfConfig *cfg);
+
+/* Fills in cfg->device_id, generating and persisting a fresh random GUID the
+ * first time. Call once after jf_config_load, before any request — the id
+ * goes in the Authorization header of every one of them, and must not change
+ * between authenticating and using the resulting token. Losing the file just
+ * means the server sees a new device; nothing breaks. */
+void jf_device_id_init(JfConfig *cfg);
+
+/* ── Quick Connect ─────────────────────────────────────────────────────────
+ * Authenticates without ever handling a password or an admin-issued API key:
+ * the client asks the server to start a request, shows the user a short code,
+ * and the user approves it from an already-signed-in Jellyfin session. What
+ * comes back is an ordinary user access token.
+ *
+ * The resulting token is a narrower credential than the API key path it
+ * replaces. An API key authenticates as the server, not as a person: which
+ * account gets its watch state updated is decided by the userId this client
+ * chooses to send (resolved from the configured username), and the same key
+ * could just as well address any other account. It's also why progress has to
+ * be reported per-user rather than through the session endpoint — see
+ * report_user_data. A Quick Connect token is the user, so neither applies. */
+
+/* 1 if the server has Quick Connect switched on, 0 if not or unreachable. */
+int jf_quick_connect_enabled(const JfConfig *cfg);
+
+/* Starts a request and fills in the secret + the code to show the user.
+ * Returns 1 on success. */
+int jf_quick_connect_initiate(const JfConfig *cfg, JfQuickConnect *qc);
+
+/* Polls a pending request: 1 = approved, 0 = still waiting, -1 = the request
+ * is gone (expired, denied, or the server forgot it). Callers should poll at
+ * a human pace — a few seconds — since it's a person walking to another
+ * device that this is waiting on. */
+int jf_quick_connect_poll(const JfConfig *cfg, const JfQuickConnect *qc);
+
+/* Exchanges an approved request for an access token, filling in cfg->token
+ * and cfg->user_id (and cfg->username, from whoever approved it). Returns 1
+ * on success. */
+int jf_quick_connect_authenticate(JfConfig *cfg, const JfQuickConnect *qc);
+
+/* Persist / restore the earned token so Quick Connect is a one-time step
+ * rather than something to repeat at every launch. Stored next to
+ * jellyfin.conf as plain text — no worse than the API key that already lives
+ * there, and anyone who can read the SD card can read both. */
+int jf_token_save(const JfConfig *cfg);
+int jf_token_load(JfConfig *cfg);
+void jf_token_clear(void);
+
+/* Cheap authenticated request, to tell a still-valid saved token from one the
+ * server has since revoked. Returns 1 if the credential works. */
+int jf_credential_works(const JfConfig *cfg);
 
 /* Looks up cfg->username in GET /Users and fills in cfg->user_id. The raw
  * Jellyfin user id (a GUID) is not something a user can easily find in the
@@ -141,8 +295,13 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max);
  * root folder has exactly 1 direct child). Returns -1 on failure. */
 int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *item_type);
 
-/* Direct children of parent_id (a view, a folder, ...). */
-int jf_list_items(const JfConfig *cfg, const char *parent_id, JfItem *out, int max);
+/* Direct children of parent_id (a view, a folder, ...), starting at
+ * start_index — one window of a potentially much longer list. Writes the
+ * server's untruncated TotalRecordCount to *total_out (may be NULL), which
+ * is what lets the caller know there's more to page to; without it a client
+ * cannot tell "that's the whole library" from "that's all that fit". */
+int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
+                   JfItem *out, int max, int64_t *total_out);
 
 /* Same shape as jf_list_items but recursive, and filtered to item_type if
  * non-NULL/non-empty (a BaseItemKind string, e.g. "MusicAlbum"). Used by
@@ -159,10 +318,31 @@ int jf_list_items_recursive(const JfConfig *cfg, const char *parent_id,
  * this, refetching a fresh batch each time the current one runs out. */
 int jf_list_random_tracks(const JfConfig *cfg, const char *parent_id, JfItem *out, int max);
 
+/* Sentinel ids for the two synthetic home-screen entries. These aren't real
+ * library views — there is nothing on the server they correspond to — so they
+ * get ids that cannot collide with a Jellyfin GUID while still surviving
+ * jf_sanitize_id unchanged (which is what makes them safe as grid-cache
+ * filenames). */
+#define JF_VIEW_RESUME  "misterfin-resume"
+#define JF_VIEW_NEXTUP  "misterfin-nextup"
+
+/* Partly-watched items across the whole library, most recently played first
+ * (Jellyfin's "Continue Watching"). Returns movies and episodes together.
+ * Writes the untruncated count to *total_out (may be NULL) so the home screen
+ * can show one without fetching the whole row. */
+int jf_list_resume(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out);
+
+/* The next unwatched episode of each series in progress (Jellyfin's
+ * "Next Up"). Episodes only, by definition. */
+int jf_list_nextup(const JfConfig *cfg, JfItem *out, int max, int64_t *total_out);
+
 /* TV hierarchy. */
 int jf_list_seasons(const JfConfig *cfg, const char *series_id, JfItem *out, int max);
+/* Paginated like jf_list_items — a season is normally short, but "all
+ * episodes of a long-running series" in one folder is not, and it costs
+ * nothing to treat both the same way. */
 int jf_list_episodes(const JfConfig *cfg, const char *series_id, const char *season_id,
-                      JfItem *out, int max);
+                      int start_index, JfItem *out, int max, int64_t *total_out);
 
 /* Fetches full details for a single item — Overview, People (cast), and the
  * Backdrop/Logo image tags — that jf_list_items() deliberately omits to keep
@@ -209,10 +389,16 @@ typedef struct {
  * exactly 40:00 worth of frames, on both mpeg2video and h264) — a
  * multi-minute stall for a deep seek, and nothing a client request
  * parameter can avoid. Only worth paying for image-based tracks, which have
- * no other way to display at all. */
+ * no other way to display at all.
+ * audio_stream_index: a JfAudioTrack.index to select a specific audio
+ * track, or -1 to let the server pick the source's default. Audio is
+ * transcoded server-side into the delivered container, so unlike a text
+ * subtitle this cannot be switched client-side — changing it means building
+ * a new URL and restarting playback at the current position. */
 int jf_stream_url(const JfConfig *cfg, const char *item_id,
                    const JfStreamProfile *profile, int64_t start_ticks,
                    const char *play_session_id, int burn_in_sub_index,
+                   int audio_stream_index,
                    char *out, int outlen);
 
 /* Builds a direct-play audio stream URL (static=true — no server transcode:

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -196,6 +196,15 @@ typedef struct {
      * take turns kicking one another out indefinitely. The API key path
      * creates no session, which is why this was harmless before. */
     char device_id[64];
+    /* Transcode resolution/bitrate requested for video, overridable from the
+     * config file (see jf_config_load). Configurable because the useful
+     * resolution ceiling on this hardware is an open question that can only
+     * be answered by measuring on a real MiSTer — and rebuilding and
+     * reflashing for each data point makes that experiment tedious enough
+     * that it doesn't get done. */
+    int  profile_width;
+    int  profile_height;
+    int  profile_bitrate;
 } JfConfig;
 
 /* One in-flight Quick Connect request. */
@@ -390,6 +399,26 @@ typedef struct {
     int max_height;
     int video_bitrate;   /* bits/sec */
 } JfStreamProfile;
+
+/* What the client asks the server to transcode down to, before mplayer scales
+ * it back up to fill the framebuffer. Deliberately small: this device decodes
+ * in scalar C with no NEON path, and total pixel count is what costs CPU —
+ * confirmed on hardware that bitrate barely matters (2Mbps and 8Mbps both sat
+ * at ~34% utime with no A/V drift) while 720x576 pegged the CPU and drifted
+ * continuously. */
+#define JF_PROFILE_DEFAULT_W    480
+#define JF_PROFILE_DEFAULT_H    270
+#define JF_PROFILE_DEFAULT_RATE 8000000
+
+/* Bounds for a profile read from the config file. Wide enough not to get in
+ * the way of experimenting, narrow enough that a typo can't ask the server
+ * for something absurd. */
+#define JF_PROFILE_MIN_W     160
+#define JF_PROFILE_MAX_W    1920
+#define JF_PROFILE_MIN_H     120
+#define JF_PROFILE_MAX_H    1080
+#define JF_PROFILE_MIN_RATE   100000
+#define JF_PROFILE_MAX_RATE 50000000
 
 /* Builds a server-transcoded progressive stream URL for direct HTTP playback
  * (mplayer opens this URL as-is — ApiKey is passed as a query param here

--- a/src/json.c
+++ b/src/json.c
@@ -1,0 +1,426 @@
+#include "json.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Guards against stack exhaustion from a pathologically nested document.
+ * Jellyfin's own responses nest maybe five deep; anything approaching this is
+ * not a real response. */
+#define JSON_MAX_DEPTH 64
+
+typedef struct {
+    JsonDoc *doc;
+    char    *p;
+    int      depth;
+    int      failed;
+} JsonParser;
+
+/* ── node pool ───────────────────────────────────────────────────────────── */
+
+/* Returns an index, never a pointer: the pool is realloc'd as it grows, so any
+ * JsonNode* held across another node_alloc() would dangle. Everything below
+ * therefore re-derives pointers from doc->nodes[idx] at the point of use. */
+static int node_alloc(JsonDoc *doc)
+{
+    if (doc->count == doc->cap) {
+        int ncap = doc->cap ? doc->cap * 2 : 128;
+        JsonNode *grown = (JsonNode *)realloc(doc->nodes, (size_t)ncap * sizeof(JsonNode));
+        if (!grown) return -1;
+        doc->nodes = grown;
+        doc->cap   = ncap;
+    }
+    int idx = doc->count++;
+    JsonNode *n = &doc->nodes[idx];
+    memset(n, 0, sizeof(*n));
+    n->first_child  = -1;
+    n->next_sibling = -1;
+    return idx;
+}
+
+/* ── scanning ────────────────────────────────────────────────────────────── */
+
+static void skip_ws(JsonParser *ps)
+{
+    while (*ps->p == ' ' || *ps->p == '\t' || *ps->p == '\n' || *ps->p == '\r')
+        ps->p++;
+}
+
+static int hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static int hex4(const char *s, unsigned *out)
+{
+    unsigned v = 0;
+    for (int i = 0; i < 4; i++) {
+        int nib = hex_nibble(s[i]);
+        if (nib < 0) return 0;
+        v = (v << 4) | (unsigned)nib;
+    }
+    *out = v;
+    return 1;
+}
+
+/* Appends one code point as UTF-8. Worst case 4 bytes out for a 12-byte
+ * surrogate-pair escape in, so writing over the source can never outrun it. */
+static void emit_utf8(char **out, unsigned cp)
+{
+    char *o = *out;
+    if (cp < 0x80) {
+        *o++ = (char)cp;
+    } else if (cp < 0x800) {
+        *o++ = (char)(0xC0 | (cp >> 6));
+        *o++ = (char)(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        *o++ = (char)(0xE0 | (cp >> 12));
+        *o++ = (char)(0x80 | ((cp >> 6) & 0x3F));
+        *o++ = (char)(0x80 | (cp & 0x3F));
+    } else {
+        *o++ = (char)(0xF0 | (cp >> 18));
+        *o++ = (char)(0x80 | ((cp >> 12) & 0x3F));
+        *o++ = (char)(0x80 | ((cp >> 6) & 0x3F));
+        *o++ = (char)(0x80 | (cp & 0x3F));
+    }
+    *out = o;
+}
+
+/* Unescapes a string literal over the top of itself and returns a pointer to
+ * it, NUL-terminated. Safe in place because every escape sequence is longer
+ * than what it decodes to, so the write cursor always trails the read cursor.
+ * On return ps->p sits just past the closing quote. */
+static char *parse_string(JsonParser *ps)
+{
+    if (*ps->p != '"') { ps->failed = 1; return NULL; }
+    ps->p++;
+
+    char *in  = ps->p;
+    char *out = ps->p;
+    char *start = out;
+
+    while (*in && *in != '"') {
+        if (*in != '\\') { *out++ = *in++; continue; }
+
+        in++;
+        switch (*in) {
+        case '"':  *out++ = '"';  in++; break;
+        case '\\': *out++ = '\\'; in++; break;
+        case '/':  *out++ = '/';  in++; break;
+        case 'b':  *out++ = '\b'; in++; break;
+        case 'f':  *out++ = '\f'; in++; break;
+        case 'n':  *out++ = '\n'; in++; break;
+        case 'r':  *out++ = '\r'; in++; break;
+        case 't':  *out++ = '\t'; in++; break;
+        case 'u': {
+            unsigned cp;
+            if (!hex4(in + 1, &cp)) { ps->failed = 1; return NULL; }
+            in += 5;
+            /* A high surrogate is only half a code point — pair it with the
+             * low surrogate that must follow. Jellyfin emits these for
+             * anything outside the BMP (emoji in a title, most commonly). */
+            if (cp >= 0xD800 && cp <= 0xDBFF && in[0] == '\\' && in[1] == 'u') {
+                unsigned lo;
+                if (hex4(in + 2, &lo) && lo >= 0xDC00 && lo <= 0xDFFF) {
+                    cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                    in += 6;
+                }
+            }
+            /* An unpaired surrogate isn't a valid code point; substituting
+             * U+FFFD keeps the string well-formed rather than emitting bytes
+             * no decoder will accept. */
+            if (cp >= 0xD800 && cp <= 0xDFFF) cp = 0xFFFD;
+            emit_utf8(&out, cp);
+            break;
+        }
+        default:
+            ps->failed = 1;
+            return NULL;
+        }
+    }
+
+    if (*in != '"') { ps->failed = 1; return NULL; }
+    ps->p = in + 1;
+    *out  = '\0';   /* at or before the closing quote, which is already consumed */
+    return start;
+}
+
+static int parse_value(JsonParser *ps);
+
+static int parse_object(JsonParser *ps)
+{
+    int idx = node_alloc(ps->doc);
+    if (idx < 0) { ps->failed = 1; return -1; }
+    ps->doc->nodes[idx].type = JSON_OBJECT;
+
+    ps->p++;   /* '{' */
+    skip_ws(ps);
+    if (*ps->p == '}') { ps->p++; return idx; }
+
+    int last = -1;
+    for (;;) {
+        skip_ws(ps);
+        char *key = parse_string(ps);
+        if (!key) { ps->failed = 1; return -1; }
+
+        skip_ws(ps);
+        if (*ps->p != ':') { ps->failed = 1; return -1; }
+        ps->p++;
+
+        int child = parse_value(ps);
+        if (child < 0) { ps->failed = 1; return -1; }
+
+        ps->doc->nodes[child].key = key;
+        if (last < 0) ps->doc->nodes[idx].first_child   = child;
+        else          ps->doc->nodes[last].next_sibling = child;
+        last = child;
+        ps->doc->nodes[idx].child_count++;
+
+        skip_ws(ps);
+        if (*ps->p == ',') { ps->p++; continue; }
+        if (*ps->p == '}') { ps->p++; return idx; }
+        ps->failed = 1;
+        return -1;
+    }
+}
+
+static int parse_array(JsonParser *ps)
+{
+    int idx = node_alloc(ps->doc);
+    if (idx < 0) { ps->failed = 1; return -1; }
+    ps->doc->nodes[idx].type = JSON_ARRAY;
+
+    ps->p++;   /* '[' */
+    skip_ws(ps);
+    if (*ps->p == ']') { ps->p++; return idx; }
+
+    int last = -1;
+    for (;;) {
+        int child = parse_value(ps);
+        if (child < 0) { ps->failed = 1; return -1; }
+
+        if (last < 0) ps->doc->nodes[idx].first_child   = child;
+        else          ps->doc->nodes[last].next_sibling = child;
+        last = child;
+        ps->doc->nodes[idx].child_count++;
+
+        skip_ws(ps);
+        if (*ps->p == ',') { ps->p++; continue; }
+        if (*ps->p == ']') { ps->p++; return idx; }
+        ps->failed = 1;
+        return -1;
+    }
+}
+
+static int parse_value(JsonParser *ps)
+{
+    if (ps->failed) return -1;
+    if (++ps->depth > JSON_MAX_DEPTH) { ps->failed = 1; return -1; }
+
+    skip_ws(ps);
+
+    int idx = -1;
+    switch (*ps->p) {
+    case '{': idx = parse_object(ps); break;
+    case '[': idx = parse_array(ps);  break;
+    case '"': {
+        char *s = parse_string(ps);
+        if (!s) break;
+        idx = node_alloc(ps->doc);
+        if (idx < 0) { ps->failed = 1; break; }
+        ps->doc->nodes[idx].type = JSON_STRING;
+        ps->doc->nodes[idx].str  = s;
+        break;
+    }
+    case 't':
+        if (strncmp(ps->p, "true", 4) != 0) { ps->failed = 1; break; }
+        ps->p += 4;
+        idx = node_alloc(ps->doc);
+        if (idx < 0) { ps->failed = 1; break; }
+        ps->doc->nodes[idx].type    = JSON_BOOL;
+        ps->doc->nodes[idx].boolean = 1;
+        break;
+    case 'f':
+        if (strncmp(ps->p, "false", 5) != 0) { ps->failed = 1; break; }
+        ps->p += 5;
+        idx = node_alloc(ps->doc);
+        if (idx < 0) { ps->failed = 1; break; }
+        ps->doc->nodes[idx].type    = JSON_BOOL;
+        ps->doc->nodes[idx].boolean = 0;
+        break;
+    case 'n':
+        if (strncmp(ps->p, "null", 4) != 0) { ps->failed = 1; break; }
+        ps->p += 4;
+        idx = node_alloc(ps->doc);
+        if (idx < 0) { ps->failed = 1; break; }
+        ps->doc->nodes[idx].type = JSON_NULL;
+        break;
+    default: {
+        if (*ps->p != '-' && (*ps->p < '0' || *ps->p > '9')) { ps->failed = 1; break; }
+        char *end_d = NULL;
+        double d = strtod(ps->p, &end_d);
+        if (end_d == ps->p) { ps->failed = 1; break; }
+        /* Parsed as an integer as well as a double: tick counts run to ~10^14
+         * and callers want them exact, without depending on how much mantissa
+         * a double happens to have left. */
+        long long ll = strtoll(ps->p, NULL, 10);
+        ps->p = end_d;
+        idx = node_alloc(ps->doc);
+        if (idx < 0) { ps->failed = 1; break; }
+        ps->doc->nodes[idx].type = JSON_NUMBER;
+        ps->doc->nodes[idx].num  = d;
+        ps->doc->nodes[idx].i64  = (int64_t)ll;
+        break;
+    }
+    }
+
+    ps->depth--;
+    return ps->failed ? -1 : idx;
+}
+
+int json_parse(JsonDoc *doc, char *text)
+{
+    memset(doc, 0, sizeof(*doc));
+    if (!text) return 0;
+    doc->text = text;
+
+    JsonParser ps = { doc, text, 0, 0 };
+    int root = parse_value(&ps);
+    if (root < 0 || ps.failed) { json_free(doc); doc->text = text; return 0; }
+
+    /* Reject trailing garbage. A response cut short by a too-small read
+     * buffer fails here rather than yielding a plausible-looking partial
+     * tree — silently short lists were exactly the old failure mode. */
+    skip_ws(&ps);
+    if (*ps.p != '\0') { json_free(doc); doc->text = text; return 0; }
+
+    return 1;
+}
+
+void json_free(JsonDoc *doc)
+{
+    if (!doc) return;
+    free(doc->nodes);
+    doc->nodes = NULL;
+    doc->count = doc->cap = 0;
+    doc->text  = NULL;   /* borrowed — the caller owns it */
+}
+
+/* ── lookup ──────────────────────────────────────────────────────────────── */
+
+const JsonNode *json_root(const JsonDoc *doc)
+{
+    if (!doc || doc->count == 0) return NULL;
+    return &doc->nodes[0];
+}
+
+const JsonNode *json_child_first(const JsonDoc *doc, const JsonNode *parent)
+{
+    if (!doc || !parent || parent->first_child < 0) return NULL;
+    return &doc->nodes[parent->first_child];
+}
+
+const JsonNode *json_child_next(const JsonDoc *doc, const JsonNode *node)
+{
+    if (!doc || !node || node->next_sibling < 0) return NULL;
+    return &doc->nodes[node->next_sibling];
+}
+
+static const JsonNode *object_member(const JsonDoc *doc, const JsonNode *obj,
+                                      const char *name, int name_len)
+{
+    if (!obj || obj->type != JSON_OBJECT) return NULL;
+    JSON_FOREACH(doc, obj, child) {
+        if (child->key &&
+            strncmp(child->key, name, (size_t)name_len) == 0 &&
+            child->key[name_len] == '\0')
+            return child;
+    }
+    return NULL;
+}
+
+static const JsonNode *array_element(const JsonDoc *doc, const JsonNode *arr, int index)
+{
+    if (!arr || arr->type != JSON_ARRAY || index < 0) return NULL;
+    JSON_FOREACH(doc, arr, child) {
+        if (index-- == 0) return child;
+    }
+    return NULL;
+}
+
+const JsonNode *json_find(const JsonDoc *doc, const JsonNode *from, const char *path)
+{
+    if (!doc) return NULL;
+    const JsonNode *cur = from ? from : json_root(doc);
+    if (!cur || !path) return cur;
+
+    const char *p = path;
+    while (*p && cur) {
+        if (*p == '.') { p++; continue; }
+
+        if (*p == '[') {
+            p++;
+            int index = 0, digits = 0;
+            while (*p >= '0' && *p <= '9') { index = index * 10 + (*p++ - '0'); digits++; }
+            if (!digits || *p != ']') return NULL;
+            p++;
+            cur = array_element(doc, cur, index);
+            continue;
+        }
+
+        const char *seg = p;
+        while (*p && *p != '.' && *p != '[') p++;
+        cur = object_member(doc, cur, seg, (int)(p - seg));
+    }
+    return cur;
+}
+
+/* ── typed reads ─────────────────────────────────────────────────────────── */
+
+const char *json_as_str(const JsonNode *n, const char *fallback)
+{
+    return (n && n->type == JSON_STRING) ? n->str : fallback;
+}
+
+int64_t json_as_i64(const JsonNode *n, int64_t fallback)
+{
+    if (!n) return fallback;
+    if (n->type == JSON_NUMBER) return n->i64;
+    if (n->type == JSON_BOOL)   return n->boolean;
+    return fallback;
+}
+
+double json_as_dbl(const JsonNode *n, double fallback)
+{
+    if (!n) return fallback;
+    if (n->type == JSON_NUMBER) return n->num;
+    if (n->type == JSON_BOOL)   return n->boolean;
+    return fallback;
+}
+
+int json_as_bool(const JsonNode *n, int fallback)
+{
+    if (!n) return fallback;
+    if (n->type == JSON_BOOL)   return n->boolean;
+    /* Jellyfin is consistent about real booleans, but treating a number as
+     * truthy costs nothing and avoids a surprising false for 1. */
+    if (n->type == JSON_NUMBER) return n->i64 != 0;
+    return fallback;
+}
+
+int json_copy_str(const JsonDoc *doc, const JsonNode *from, const char *path,
+                   char *out, int outlen)
+{
+    if (!out || outlen <= 0) return 0;
+    out[0] = '\0';
+
+    const JsonNode *n = json_find(doc, from, path);
+    const char *s = json_as_str(n, NULL);
+    if (!s) return 0;
+
+    strncpy(out, s, (size_t)outlen - 1);
+    out[outlen - 1] = '\0';
+    return 1;
+}

--- a/src/json.h
+++ b/src/json.h
@@ -1,0 +1,100 @@
+#pragma once
+#include <stdint.h>
+
+/* A small, complete JSON parser — enough to stop guessing at structure with
+ * string searches.
+ *
+ * What it replaces was a set of flat strstr() scans for "key" anywhere in the
+ * response. That worked only because Jellyfin happens to serialize its DTO
+ * properties in an order where the field you wanted came before any nested
+ * object that reused the same name — an invariant that lives in the order of
+ * property declarations in a C# class upstream, and which nothing upstream
+ * knows it is maintaining. It also could not handle \uXXXX escapes at all,
+ * and Jellyfin escapes every non-ASCII character AND apostrophes that way, so
+ * an ordinary title like "Don't Look Up" came through as "Donu0027t Look Up".
+ *
+ * Design notes:
+ * - Parses in place. Strings are unescaped over the top of the source text
+ *   (the unescaped form is never longer) and NUL-terminated, so a JsonNode's
+ *   `str` points straight into the caller's buffer with no extra copies.
+ *   That buffer must therefore stay alive and unmodified for the document's
+ *   whole lifetime.
+ * - Nodes live in one growable pool addressed by index rather than as
+ *   individually allocated cells, so parsing a large response is a handful of
+ *   reallocs rather than thousands of small mallocs.
+ * - Every accessor tolerates a NULL node, so a lookup chain that misses can
+ *   be read straight into a default without a separate presence check.
+ */
+
+typedef enum {
+    JSON_NULL,
+    JSON_BOOL,
+    JSON_NUMBER,
+    JSON_STRING,
+    JSON_ARRAY,
+    JSON_OBJECT
+} JsonType;
+
+typedef struct {
+    JsonType    type;
+    const char *key;          /* member name; NULL for array elements and the root */
+    const char *str;          /* JSON_STRING: unescaped, NUL-terminated, UTF-8 */
+    double      num;          /* JSON_NUMBER */
+    int64_t     i64;          /* JSON_NUMBER, parsed as an integer separately so
+                               * large tick counts don't go through a double */
+    int         boolean;      /* JSON_BOOL */
+    int         first_child;  /* node index, -1 if none */
+    int         next_sibling; /* node index, -1 if none */
+    int         child_count;  /* members of an object / elements of an array */
+} JsonNode;
+
+typedef struct {
+    JsonNode *nodes;
+    int       count;
+    int       cap;
+    char     *text;   /* borrowed and mutated in place — NOT owned or freed */
+} JsonDoc;
+
+/* Parses `text` in place. Returns 1 on success, 0 on malformed input (in
+ * which case the doc is left empty and safe to json_free). `text` must remain
+ * valid and unmodified until json_free — every string in the tree points into
+ * it. Trailing content after the top-level value is rejected, so a response
+ * truncated mid-object fails loudly instead of silently yielding a short list,
+ * which is exactly the failure the old scanner turned into missing rows.
+ *
+ * `doc` must be fresh or already json_free'd: this takes it as uninitialized
+ * and overwrites it, so parsing twice into the same doc without freeing in
+ * between leaks the first tree. */
+int  json_parse(JsonDoc *doc, char *text);
+void json_free(JsonDoc *doc);
+
+const JsonNode *json_root(const JsonDoc *doc);
+
+/* Looks up a dotted path relative to `from` (NULL means the document root).
+ * Supports object members and array subscripts:
+ *     "Name"
+ *     "ImageTags.Primary"
+ *     "MediaStreams[0].Codec"
+ * Returns NULL if any step is missing or the wrong type. */
+const JsonNode *json_find(const JsonDoc *doc, const JsonNode *from, const char *path);
+
+/* Child iteration, for arrays and objects alike. */
+const JsonNode *json_child_first(const JsonDoc *doc, const JsonNode *parent);
+const JsonNode *json_child_next (const JsonDoc *doc, const JsonNode *node);
+
+#define JSON_FOREACH(doc, parent, it) \
+    for (const JsonNode *it = json_child_first((doc), (parent)); \
+         it != NULL; it = json_child_next((doc), it))
+
+/* Typed reads. All accept node == NULL and return the fallback, so a missing
+ * field and a present-but-wrong-type field behave identically. */
+const char *json_as_str (const JsonNode *n, const char *fallback);
+int64_t     json_as_i64 (const JsonNode *n, int64_t fallback);
+double      json_as_dbl (const JsonNode *n, double fallback);
+int         json_as_bool(const JsonNode *n, int fallback);
+
+/* json_find + json_as_str + bounded copy. Returns 1 if the path resolved to a
+ * string (and something was copied), 0 otherwise — in which case `out` is
+ * left as an empty string rather than untouched. */
+int json_copy_str(const JsonDoc *doc, const JsonNode *from, const char *path,
+                   char *out, int outlen);

--- a/src/main.c
+++ b/src/main.c
@@ -511,12 +511,34 @@ static int draw_wrapped(FBDev *fb, int x, int y, const char *text,
 
 /* ── input (evdev gamepad, same model as MiSTerDVD) ─────────────────────── */
 
-#define MAX_INPUT_FDS 8
+/* Bit-array helpers for the evdev state ioctls below (linux/input.h returns
+ * these as an array of unsigned long). */
+#define INPUT_BITS_PER_LONG  (8 * (int)sizeof(unsigned long))
+#define INPUT_NLONGS(n)      (((n) + INPUT_BITS_PER_LONG - 1) / INPUT_BITS_PER_LONG)
+#define INPUT_TEST_BIT(arr, bit) \
+    ((arr)[(bit) / INPUT_BITS_PER_LONG] & (1UL << ((bit) % INPUT_BITS_PER_LONG)))
+
+/* Was 8. A MiSTer has well over that many /dev/input/event* nodes once
+ * keyboards, mice, the MiSTer virtual input device and a pad or two are
+ * present — and a single pad often exposes several. With a hard cap and no
+ * eviction, which devices got opened came down to readdir order, which is
+ * filesystem order rather than anything meaningful. */
+#define MAX_INPUT_FDS 32
 static int  input_fds[MAX_INPUT_FDS];
 static int  input_swap_ab[MAX_INPUT_FDS];
 static int  input_is_virtual[MAX_INPUT_FDS];
 static char input_names[MAX_INPUT_FDS][32];   /* e.g. "event0" — see input_open() */
 static int  input_count = 0;
+/* MISTERFIN_INPUT_DEBUG=1 — prints every incoming event with its device, raw
+ * code, and what it mapped to (or why it was dropped). MiSTer's input routing
+ * is genuinely unusual: it grabs directly-wired USB pads exclusively and
+ * re-emits them on a synthetic "MiSTer virtual input" device, so which button
+ * arrives on which node, under which code, varies by pad and by connection
+ * type. Guessing at that from a bug report is hopeless; this makes it a
+ * two-minute answer. Output goes to stderr, so run over SSH — it doesn't
+ * touch the framebuffer UI. */
+static int  input_debug = 0;
+
 
 /* Some 8BitDo SNES-style pads (confirmed on the SFC30 via raw evdev capture)
  * report their printed A/B buttons as BTN_SOUTH/BTN_EAST swapped relative to
@@ -555,6 +577,18 @@ static int device_is_mister_virtual(const char *name)
 #define INP_L      0x100
 #define INP_R      0x200
 
+static const char *inp_bit_name(int bit)
+{
+    switch (bit) {
+    case INP_UP: return "UP";       case INP_DOWN:  return "DOWN";
+    case INP_LEFT: return "LEFT";   case INP_RIGHT: return "RIGHT";
+    case INP_A: return "A";         case INP_B:     return "B";
+    case INP_START: return "START"; case INP_SELECT: return "SELECT";
+    case INP_L: return "L";         case INP_R:      return "R";
+    default: return "?";
+    }
+}
+
 /* Safe to call repeatedly (see the periodic re-scan in the main loop) —
  * skips any /dev/input/eventN already tracked, only opening ones that are
  * new since the last call (a reconnected wireless pad, for example, can
@@ -571,6 +605,7 @@ static void input_open(void)
      * the old behavior on real hardware. Safe to call repeatedly, same as
      * the evdev scan below (see this function's own header comment). */
     if (getenv("MISTERFIN_STDIN")) stdin_input_open();
+    if (getenv("MISTERFIN_INPUT_DEBUG")) input_debug = 1;
     script_open();
 
     DIR *d = opendir("/dev/input");
@@ -589,17 +624,56 @@ static void input_open(void)
         int fd = open(path, O_RDONLY | O_NONBLOCK);
         if (fd < 0) continue;
 
+        /* Skip anything with neither buttons nor axes. A system has plenty of
+         * such nodes (power buttons, lid switches, accelerometers, the
+         * console's own pseudo-devices) and every one of them used to occupy
+         * a slot that a real controller then couldn't have. */
+        unsigned long evbits[INPUT_NLONGS(EV_MAX + 1)];
+        memset(evbits, 0, sizeof(evbits));
+        if (ioctl(fd, EVIOCGBIT(0, sizeof(evbits)), evbits) < 0 ||
+            (!INPUT_TEST_BIT(evbits, EV_KEY) && !INPUT_TEST_BIT(evbits, EV_ABS))) {
+            close(fd);
+            continue;
+        }
+
         char name[128] = "";
         ioctl(fd, EVIOCGNAME(sizeof(name)), name);
         input_swap_ab[input_count]    = device_needs_ab_swap(name);
         input_is_virtual[input_count] = device_is_mister_virtual(name);
         strncpy(input_names[input_count], e->d_name, sizeof(input_names[0]) - 1);
         input_fds[input_count++] = fd;
+        if (input_debug)
+            fprintf(stderr, "[input] opened %s \"%s\"%s (%d tracked)\n",
+                    e->d_name, name,
+                    device_is_mister_virtual(name) ? " [MiSTer virtual]" : "",
+                    input_count);
     }
     closedir(d);
 }
 
 static void input_repeat_reset(void);   /* forward decl — defined with the repeat logic below */
+
+/* Drops a device that has disappeared, compacting the parallel arrays.
+ *
+ * Without this, a controller that disconnects and comes back — which is
+ * routine for anything wireless, and is exactly what happens after a pad
+ * freezes and gets reconnected — leaves its dead entry holding a slot
+ * forever while the live node needs a new one. Slots leak on every reconnect
+ * until nothing new can be opened at all, and buttons simply stop arriving
+ * with no visible cause. */
+static void input_drop_slot(int i)
+{
+    if (input_debug)
+        fprintf(stderr, "[input] %s went away, releasing slot\n", input_names[i]);
+    close(input_fds[i]);
+    for (int j = i; j < input_count - 1; j++) {
+        input_fds[j]        = input_fds[j + 1];
+        input_swap_ab[j]    = input_swap_ab[j + 1];
+        input_is_virtual[j] = input_is_virtual[j + 1];
+        memcpy(input_names[j], input_names[j + 1], sizeof(input_names[0]));
+    }
+    input_count--;
+}
 
 static void input_drain(void)
 {
@@ -831,7 +905,12 @@ static int input_poll(void)
     struct input_event ev;
     int mask = stdin_poll() | script_poll();
     for (int i = 0; i < input_count; i++) {
-        while (read(input_fds[i], &ev, sizeof(ev)) == (ssize_t)sizeof(ev)) {
+        /* Reading a removed device fails with ENODEV; that's how a
+         * disconnect is noticed, since evdev has no other notification.
+         * Dropping the slot here is what lets the same pad be picked up
+         * again by the next rescan. */
+        ssize_t got;
+        while ((got = read(input_fds[i], &ev, sizeof(ev))) == (ssize_t)sizeof(ev)) {
             /* Press edges only. Releases don't need tracking here: auto-repeat
              * reads the device's real current state instead of reconstructing
              * it from edges (see input_repeat). The kernel's own key repeat
@@ -859,6 +938,10 @@ static int input_poll(void)
                     code != KEY_UP && code != KEY_DOWN &&
                     code != KEY_LEFT && code != KEY_RIGHT &&
                     code != KEY_ENTER && code != KEY_ESC && code != KEY_BACK) {
+                    if (input_debug)
+                        fprintf(stderr, "[input] %s EV_KEY code=%d val=%d -> DROPPED "
+                                        "(not trusted from MiSTer virtual input)\n",
+                                input_names[i], code, ev.value);
                     continue;
                 }
                 int bit = 0;
@@ -884,8 +967,16 @@ static int input_poll(void)
                 case BTN_TL: case KEY_PAGEUP:    bit = INP_L;     break;
                 case BTN_TR: case KEY_PAGEDOWN:  bit = INP_R;     break;
                 }
+                if (input_debug)
+                    fprintf(stderr, "[input] %s EV_KEY code=%d val=%d -> %s\n",
+                            input_names[i], code, ev.value,
+                            bit ? inp_bit_name(bit) : "unmapped");
                 mask |= bit;
             } else if (ev.type == EV_ABS) {
+                if (input_debug && (ev.code == ABS_HAT0X || ev.code == ABS_HAT0Y))
+                    fprintf(stderr, "[input] %s EV_ABS %s value=%d\n",
+                            input_names[i],
+                            ev.code == ABS_HAT0X ? "HAT0X" : "HAT0Y", ev.value);
                 if (ev.code == ABS_HAT0Y) {
                     if (ev.value == -1) mask |= INP_UP;
                     if (ev.value ==  1) mask |= INP_DOWN;
@@ -895,6 +986,10 @@ static int input_poll(void)
                     if (ev.value ==  1) mask |= INP_RIGHT;
                 }
             }
+        }
+        if (got < 0 && (errno == ENODEV || errno == EBADF)) {
+            input_drop_slot(i);
+            i--;            /* the slot now holds the next device */
         }
     }
     return mask;
@@ -936,13 +1031,6 @@ static void input_repeat_reset(void)
      * lets go of everything. */
     repeat_suppressed = 1;
 }
-
-/* Bit-array helpers for the evdev state ioctls below (linux/input.h returns
- * these as an array of unsigned long). */
-#define INPUT_BITS_PER_LONG  (8 * (int)sizeof(unsigned long))
-#define INPUT_NLONGS(n)      (((n) + INPUT_BITS_PER_LONG - 1) / INPUT_BITS_PER_LONG)
-#define INPUT_TEST_BIT(arr, bit) \
-    ((arr)[(bit) / INPUT_BITS_PER_LONG] & (1UL << ((bit) % INPUT_BITS_PER_LONG)))
 
 /* Asks each device what it is ACTUALLY holding right now, via EVIOCGKEY /
  * EVIOCGABS, rather than reconstructing it from the press/release stream.
@@ -3688,6 +3776,10 @@ static int    g_submenu_tab        = SUBMENU_TAB_SUBS;
 static int    g_submenu_sub_sel    = 0;   /* 0 = Off, i+1 = g_info_item.subs[i] */
 static int    g_submenu_audio_sel  = 0;   /* index into g_info_item.audio[] */
 static int    g_submenu_was_paused = 0;   /* pause state before the menu opened, to restore on close */
+/* When the menu was opened, so a duplicate of the opening press can't close
+ * it again — see the close handling in the main loop. */
+static double g_submenu_opened_at = 0.0;
+#define SUBMENU_IGNORE_CLOSE_SEC 0.30
 
 /* Which audio track the server would pick if we said nothing — used to show
  * a meaningful "current" marker before the user has chosen anything, and as
@@ -3776,6 +3868,7 @@ static void submenu_open(FBDev *fb)
         g_submenu_tab = SUBMENU_TAB_AUDIO;
 
     g_submenu_was_paused = g_paused;
+    g_submenu_opened_at  = now_sec();
     if (!g_paused) player_pause_toggle();
     submenu_bg_capture(fb);
     memcpy(fb->back, fb->mem, (size_t)fb->stride * fb->height);
@@ -4893,8 +4986,22 @@ int main(int argc, char **argv)
              * silent no-op before (it only opens from the STATE_PLAYING
              * switch below, which this block's own `continue` never
              * reaches while visible), so a second SELECT looked like "the
-             * menu doesn't open". B still means an explicit cancel too. */
-            if (inp & (INP_B | INP_SELECT)) { submenu_close(); input_drain(); continue; }
+             * menu doesn't open". B still means an explicit cancel too.
+             *
+             * Ignored for a moment after opening, though. The press that
+             * opens this menu can be reported twice — a pad that enumerates
+             * as several event nodes, or MiSTer's own OSD echoing physical
+             * input onto a second virtual device, both do that — and if the
+             * duplicate lands in a later poll than the original it arrives
+             * here and closes the menu immediately. Draining on open only
+             * discards what was already queued at that instant, so a
+             * duplicate a few milliseconds behind still gets through; the
+             * menu then flickers open and shut and reads as "the button
+             * doesn't reliably work". */
+            if ((inp & (INP_B | INP_SELECT)) &&
+                loop_now - g_submenu_opened_at > SUBMENU_IGNORE_CLOSE_SEC) {
+                submenu_close(); input_drain(); continue;
+            }
             /* Redraw every single frame, unconditionally — mplayer writes
              * video frames directly to fb->mem (bypassing our fb->back
              * entirely) and was confirmed on hardware to still do so
@@ -5152,7 +5259,7 @@ int main(int argc, char **argv)
                 state = STATE_BROWSE;
                 draw_browse(&fb);
             } else if (g_paused) {
-                if (inp & INP_SELECT) { submenu_open(&fb); draw_submenu(&fb); continue; }
+                if (inp & INP_SELECT) { submenu_open(&fb); draw_submenu(&fb); input_drain(); continue; }
                 if (inp & INP_LEFT)  seek_accumulate(-SEEK_STEP, loop_now);
                 if (inp & INP_RIGHT) seek_accumulate(+SEEK_STEP, loop_now);
                 if (inp & INP_A) player_pause_toggle();
@@ -5171,7 +5278,7 @@ int main(int argc, char **argv)
                  * to actually fire the restart. */
                 draw_paused(&fb, g_info_item.name, seek_pending_target());
             } else {
-                if (inp & INP_SELECT) { submenu_open(&fb); draw_submenu(&fb); continue; }
+                if (inp & INP_SELECT) { submenu_open(&fb); draw_submenu(&fb); input_drain(); continue; }
                 if (inp & INP_A) player_pause_toggle();
                 if (inp & INP_LEFT)  seek_accumulate(-SEEK_STEP, loop_now);
                 if (inp & INP_RIGHT) seek_accumulate(+SEEK_STEP, loop_now);

--- a/src/main.c
+++ b/src/main.c
@@ -3337,6 +3337,8 @@ static void draw_timeline(FBDev *fb, int y, double pos, double duration)
     draw_text(fb, (fb->width - text_width(fb, label, 1)) / 2, y + 10, label, 1, COL_ITEM);
 }
 
+static JfStreamProfile stream_profile(void);   /* forward decl — defined with the playback code */
+
 static void draw_paused(FBDev *fb, const char *name, double pos)
 {
     memcpy(fb->back, fb->mem, (size_t)fb->stride * fb->height);
@@ -3351,14 +3353,29 @@ static void draw_paused(FBDev *fb, const char *name, double pos)
     snprintf(nbuf, sizeof(nbuf), "%.60s", name);
     draw_text(fb, (fb->width - text_width(fb, nbuf, 1)) / 2, cy + 20, nbuf, 1, COL_ITEM);
 
+    /* The transcode actually in effect. Shown because it's configurable now
+     * and the whole reason it is configurable is to be swept on hardware —
+     * having to infer which profile is live from a config file you edited
+     * three reboots ago is exactly how that measurement goes wrong. */
+    {
+        JfStreamProfile p = stream_profile();
+        char pbuf[48];
+        snprintf(pbuf, sizeof(pbuf), "%dx%d @ %.1f Mbps",
+                 p.max_width, p.max_height, p.video_bitrate / 1000000.0);
+        draw_text(fb, (fb->width - text_width(fb, pbuf, 1)) / 2, cy + 32, pbuf, 1, COL_HINT);
+    }
+
     /* -20 leaves only ~2px between the timeline's time label and the hint
      * row below on PAL too (same formula), but it's only been reported as
      * too tight on NTSC — leaving PAL's spacing exactly as-is per instr. */
     draw_timeline(fb, fb->height - 8 - SAFE_Y_BOT - (fb->height == 288 ? 20 : 28), pos,
                   (double)g_info_item.runtime_ticks / 10000000.0);
 
-    const char *hint = (g_info_item.sub_count > 0)
-        ? "B:resume  A:stop  L/R:vsync  SELECT:subs"
+    /* SELECT now opens a picker with an audio tab as well, so it's worth
+     * offering on a title that has alternate audio but no subtitles at all —
+     * the old condition hid it in exactly that case. */
+    const char *hint = (g_info_item.sub_count > 0 || g_info_item.audio_count > 1)
+        ? "B:resume  A:stop  L/R:vsync  SELECT:tracks"
         : "B:resume  A:stop  L/R:vsync";
     draw_text(fb, (fb->width - text_width(fb, hint, 1)) / 2,
               fb->height - 8 - SAFE_Y_BOT, hint, 1, COL_HINT);
@@ -3428,7 +3445,18 @@ static double   g_vu_level_l = 0.0, g_vu_level_r = 0.0;   /* attack/decay state,
  * ~34-35% avg utime, A-V desync stayed at 0.000 either way); resolution is
  * what actually costs CPU (see the native-PAL note above), so there's no
  * real reason not to spend the extra bitrate on quality here. */
-static const JfStreamProfile g_stream_profile = { .max_width = 480, .max_height = 270, .video_bitrate = 8000000 };
+/* Assembled from the config each time rather than being a constant, so a
+ * resolution can be tried on hardware by editing jellyfin.conf instead of
+ * rebuilding and reflashing per data point. Defaults to the values above when
+ * the config says nothing. */
+static JfStreamProfile stream_profile(void)
+{
+    JfStreamProfile p;
+    p.max_width     = g_cfg.profile_width;
+    p.max_height    = g_cfg.profile_height;
+    p.video_bitrate = g_cfg.profile_bitrate;
+    return p;
+}
 
 static void mp_cmd(const char *cmd)
 {
@@ -4024,7 +4052,8 @@ static void play(FBDev *fb, const char *item_id, double offset_secs)
     jf_make_play_session_id(g_play_session_id, sizeof(g_play_session_id));
 
     char url[700];
-    jf_stream_url(&g_cfg, item_id, &g_stream_profile, start_ticks, g_play_session_id,
+    const JfStreamProfile profile = stream_profile();
+    jf_stream_url(&g_cfg, item_id, &profile, start_ticks, g_play_session_id,
                   g_burned_in_sub_index, g_current_audio_index, url, sizeof(url));
 
     char delay_arg[16];

--- a/src/main.c
+++ b/src/main.c
@@ -1176,9 +1176,9 @@ static const char *collection_item_type(const char *collection_type)
  * they aren't libraries — no ParentId to list, no collection type, and their
  * contents change every time something is watched. Everything that would
  * normally reach for the server via a view id has to route around them. */
-static int view_is_resume(const JfItem *v) { return !strcmp(v->id, JF_VIEW_RESUME); }
-static int view_is_nextup(const JfItem *v) { return !strcmp(v->id, JF_VIEW_NEXTUP); }
-static int view_is_synthetic(const JfItem *v) { return view_is_resume(v) || view_is_nextup(v); }
+static int view_is_resume(const JfItem *v) { return v->synthetic == JF_SYNTH_RESUME; }
+static int view_is_nextup(const JfItem *v) { return v->synthetic == JF_SYNTH_NEXTUP; }
+static int view_is_synthetic(const JfItem *v) { return v->synthetic != 0; }
 
 /* Episodes in these rows arrive out of context — the row mixes shows, so a
  * name like "Episode 03" identifies nothing. Fold the series name and season/
@@ -1206,11 +1206,24 @@ static void home_row_label_episodes(void)
 /* Loads the window of the current frame's list that starts at start_index.
  * Only the list itself moves — the frame stack, and which frame is current,
  * are untouched, so this is equally the "open this frame" path (start 0) and
- * the "scroll past the end of what's loaded" path. */
-static void fetch_frame_window(int start_index)
+ * the "scroll past the end of what's loaded" path.
+ *
+ * Returns 1 on success, 0 if the fetch failed — in which case the previously
+ * loaded window is left intact. */
+static int fetch_frame_window(int start_index)
 {
     BrowseFrame *f = &g_stack[g_stack_depth - 1];
     if (start_index < 0) start_index = 0;
+
+    /* Saved so a failed fetch can put the window back exactly as it was —
+     * committing the new start and a recomputed total on failure left the
+     * cursor pointing into a list that had just been emptied, which rendered
+     * a perfectly healthy library as "Nothing here". */
+    const int     prev_window_start = g_window_start;
+    const int64_t prev_total_count  = g_total_count;
+    const int     prev_item_count   = g_item_count;
+
+    int paginated = 0;   /* only these kinds have more rows than one fetch returns */
 
     g_window_start = start_index;
     g_total_count  = -1;
@@ -1233,9 +1246,9 @@ static void fetch_frame_window(int start_index)
          * "Continue...". The full name is used for the frame title once you
          * drill in (see the STATE_BROWSE handler), where there's room. */
         int n_synth = 0;
-        static const struct { const char *id, *name; } synth[] = {
-            { JF_VIEW_RESUME, "Continue" },
-            { JF_VIEW_NEXTUP, "Next Up" },
+        static const struct { const char *id, *name; int kind; } synth[] = {
+            { JF_VIEW_RESUME, "Continue", JF_SYNTH_RESUME },
+            { JF_VIEW_NEXTUP, "Next Up",  JF_SYNTH_NEXTUP },
         };
         for (int s = 0; s < 2; s++) {
             JfItem probe[1];
@@ -1250,6 +1263,7 @@ static void fetch_frame_window(int start_index)
             strncpy(card->id,   synth[s].id,   sizeof(card->id) - 1);
             strncpy(card->name, synth[s].name, sizeof(card->name) - 1);
             card->type = JF_TYPE_FOLDER;
+            card->synthetic = synth[s].kind;
             card->index_number = -1;
             g_view_counts[n_synth] = total;
             n_synth++;
@@ -1281,6 +1295,7 @@ static void fetch_frame_window(int start_index)
          * could be drawn. They now ride along on the listing itself as
          * RecursiveItemCount, which the server computes for the whole
          * result set in a single batched query. See JfItem's own comment. */
+        paginated = 1;
         g_item_count = jf_list_items(&g_cfg, f->parent_id, start_index,
                                       g_items, JF_PAGE_SIZE, &g_total_count);
         break;
@@ -1289,14 +1304,30 @@ static void fetch_frame_window(int start_index)
         g_item_count = jf_list_seasons(&g_cfg, f->series_id, g_items, JF_MAX_ITEMS);
         break;
     case FRAME_EPISODES:
+        paginated = 1;
         g_item_count = jf_list_episodes(&g_cfg, f->series_id, f->season_id, start_index,
                                          g_items, JF_PAGE_SIZE, &g_total_count);
         break;
     }
-    /* No TotalRecordCount came back (older server, or an endpoint that
-     * doesn't report one) — treat what's loaded as the whole list, which is
-     * the pre-pagination behavior and degrades safely. */
-    if (g_total_count < 0) g_total_count = g_window_start + g_item_count;
+    if (g_item_count < 0) {
+        /* The request failed (as opposed to legitimately returning nothing).
+         * Restore the window we already had rather than commit an empty one. */
+        g_window_start = prev_window_start;
+        g_total_count  = prev_total_count;
+        g_item_count   = prev_item_count;
+        return 0;
+    }
+
+    /* For everything that isn't paginated, what's loaded IS the whole list —
+     * overwrite rather than fall back. The home rows ask the server for a
+     * total and then cap the fetch at HOME_ROW_MAX, so on an account with
+     * more than that the total legitimately exceeds what's loaded; leaving it
+     * in place made browse_move_sel think there was another page, and it
+     * re-fetched the same rows on every keypress. With auto-repeat that is a
+     * blocking HTTP request every 45ms for as long as DOWN is held. */
+    if (!paginated || g_total_count < 0)
+        g_total_count = g_window_start + g_item_count;
+    return 1;
 }
 
 static void fetch_frame(void)
@@ -1400,6 +1431,9 @@ static int browse_move_sel(FBDev *fb, int delta)
 {
     if (delta == 0) return 0;
 
+    /* Clamped on ingest: TotalRecordCount is server-supplied, and an absurd
+     * value would otherwise reach the signed arithmetic below. */
+    if (g_total_count > JF_MAX_TOTAL_ITEMS) g_total_count = JF_MAX_TOTAL_ITEMS;
     int total = (int)g_total_count;
     if (total <= 0) total = g_item_count;
     if (total <= 0) return 0;
@@ -1411,11 +1445,24 @@ static int browse_move_sel(FBDev *fb, int delta)
     if (new_abs == abs_sel) return 0;
 
     if (new_abs < g_window_start || new_abs >= g_window_start + g_item_count) {
-        fetch_frame_window((new_abs / JF_PAGE_SIZE) * JF_PAGE_SIZE);
-        g_scroll = 0;   /* old window's scroll offset means nothing now */
-        if (g_item_count <= 0) return 0;   /* fetch failed — leave the cursor put */
+        int target_start = (new_abs / JF_PAGE_SIZE) * JF_PAGE_SIZE;
+
+        /* Only fetch if that's genuinely a different window. The destination
+         * can land outside the loaded rows while still belonging to the page
+         * we already have — a list shorter than JF_PAGE_SIZE whose reported
+         * total is larger does exactly that at its last row. Re-fetching there
+         * meant one blocking request per keypress, and with auto-repeat, per
+         * repeat tick. */
+        if (target_start != g_window_start) {
+            if (!fetch_frame_window(target_start)) return 0;   /* window left intact */
+            g_scroll = 0;   /* old window's scroll offset means nothing now */
+        }
+
+        if (g_item_count <= 0) return 0;
         if (new_abs >= g_window_start + g_item_count)
             new_abs = g_window_start + g_item_count - 1;
+        if (new_abs < g_window_start) new_abs = g_window_start;
+        if (new_abs == abs_sel) return 0;   /* clamped back to where we started */
     }
 
     g_sel = new_abs - g_window_start;
@@ -2106,13 +2153,19 @@ static void *quick_connect_thread(void *arg)
     g_qc_state = QC_WAITING;
     pthread_mutex_unlock(&g_qc_mutex);
 
-    int elapsed = 0, consecutive_errors = 0;
-    while (elapsed < QC_TIMEOUT_SEC && g_running) {
-        sleep(QC_POLL_INTERVAL_SEC);
+    int elapsed = 0, consecutive_errors = 0, approved = 0;
+    while (g_running) {
+        /* Slept in short slices rather than one long sleep so quitting is
+         * responsive: the app can exit while this is waiting, and a 3-second
+         * sleep meant up to 3 seconds of a detached thread still running
+         * against a torn-down process. */
+        for (int slept = 0; slept < QC_POLL_INTERVAL_SEC * 10 && g_running; slept++)
+            usleep(100 * 1000);
+        if (!g_running) return NULL;
         elapsed += QC_POLL_INTERVAL_SEC;
 
         int poll = jf_quick_connect_poll(&g_cfg, &qc);
-        if (poll == 1) break;
+        if (poll == 1) { approved = 1; break; }
         if (poll < 0) {
             /* A poll failure is ambiguous — the request really being gone
              * looks the same as the wifi hiccupping. Tolerate a couple before
@@ -2122,8 +2175,14 @@ static void *quick_connect_thread(void *arg)
         } else {
             consecutive_errors = 0;
         }
+
+        /* Checked AFTER the poll, not before it. Testing first meant the
+         * final poll never ran, so an approval given in the last few seconds
+         * was discarded — and it's single-use, so the user's code was burned
+         * for nothing. */
+        if (elapsed >= QC_TIMEOUT_SEC) break;
     }
-    if (elapsed >= QC_TIMEOUT_SEC) { qc_set_state(QC_FAILED); return NULL; }
+    if (!approved) { qc_set_state(QC_FAILED); return NULL; }
     if (!g_running) return NULL;
 
     if (!jf_quick_connect_authenticate(&g_cfg, &qc)) { qc_set_state(QC_FAILED); return NULL; }
@@ -2491,7 +2550,11 @@ static int grid_cache_load_from_disk(GridLibCache *gc, const JfItem *view, const
         int32_t w = 0, h = 0;
         size_t need;
         if (fread(&w, sizeof(w), 1, f) != 1 || fread(&h, sizeof(h), 1, f) != 1 ||
-            w <= 0 || h <= 0 || (need = (size_t)w * (size_t)h * 4) > 4 * 1024 * 1024) {
+            /* Bounded individually before multiplying: size_t is 32-bit on
+             * the ARM target, so w*h*4 can wrap and slip under the 4MB guard
+             * on a corrupted cache file. */
+            w <= 0 || h <= 0 || w > 4096 || h > 4096 ||
+            (need = (size_t)w * (size_t)h * 4) > 4 * 1024 * 1024) {
             fclose(f);
             for (int k = 0; k < gc->count; k++) { free(gc->px[k]); gc->px[k] = NULL; }
             gc->count = 0;
@@ -2569,7 +2632,10 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
     } else {
         if (grid_cache_load_from_disk(gc, view, item_type)) {
             grid_cell_order_shuffle(gc);
-            gc->ready = 1;
+            /* Release: everything written above must be visible to any
+             * thread that observes ready == 1. See the acquire in
+             * draw_grid_background. */
+            __atomic_store_n(&gc->ready, 1, __ATOMIC_RELEASE);
             return;
         }
         n = jf_list_items_recursive(&g_cfg, view->id, item_type, grid_items, GRID_FETCH_MAX);
@@ -2590,7 +2656,7 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
         int64_t count = jf_count_items(&g_cfg, view->id, item_type);
         if (count >= 0) grid_cache_save_to_disk(gc, view->id, count);
     }
-    gc->ready = 1;
+    __atomic_store_n(&gc->ready, 1, __ATOMIC_RELEASE);
 }
 
 /* Already-cached libraries (checked here under g_grid_mutex) return
@@ -2663,7 +2729,7 @@ static void draw_grid_background(FBDev *fb)
 {
     if (g_grid_active < 0) return;
     GridLibCache *gc = &g_grid_cache[g_grid_active];
-    if (!gc->ready || gc->count == 0) return;
+    if (!__atomic_load_n(&gc->ready, __ATOMIC_ACQUIRE) || gc->count == 0) return;
     int cell_w = fb->width / GRID_COLS, cell_h = fb->height / GRID_ROWS;
     for (int row = 0; row < GRID_ROWS; row++) {
         for (int col = 0; col < GRID_COLS; col++) {
@@ -5124,6 +5190,12 @@ int main(int argc, char **argv)
             usleep(16000);
         }
     }
+
+    /* The Quick Connect thread can still be polling when the user quits. It
+     * checks g_running in 100ms slices, so this waits well under a second —
+     * but without it, main() returning would run glibc's exit-time FILE
+     * cleanup underneath a thread that is mid-read on a curl pipe. */
+    if (qc_running) { pthread_join(qc_tid, NULL); qc_running = 0; }
 
     player_stop();
     info_assets_free();

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include <sys/ioctl.h>
 #include <linux/input.h>
 #include <linux/kd.h>
+#include <termios.h>
 #include <time.h>
 #include <ctype.h>
 #include <pthread.h>
@@ -28,6 +29,7 @@
 #include "stb_image.h"
 #include "ddr.h"
 #include "jellyfin.h"
+#include "subtitles.h"
 
 #define MPLAYER      "/media/fat/misterfin/mplayer-arm"
 #define POSTER_TMP   "/tmp/misterfin_poster.img"
@@ -248,8 +250,18 @@ static void about_start_install(void)
     pthread_detach(tid);
 }
 
+/* Set from fb.headless right after fb_open — see the MISTERFIN_FB comment in
+ * fb.c. Guards the handful of places that touch real console/FPGA hardware
+ * with no meaningful desktop equivalent. */
+static int g_headless = 0;
+
 static void cursor_hide(void)
 {
+    /* Off-hardware the "console" this would grab is the developer's own
+     * terminal emulator — KD_GRAPHICS is a harmless ENOTTY there, but the
+     * clear-screen write is not, and it fights the raw-mode stdin backend
+     * for the same tty. */
+    if (g_headless) return;
     const char *ttys[] = { "/dev/tty0", "/dev/tty1", "/dev/tty", "/dev/console", NULL };
     for (int i = 0; ttys[i]; i++) {
         int fd = open(ttys[i], O_RDWR | O_NONBLOCK);
@@ -265,6 +277,7 @@ static void cursor_hide(void)
 
 static void cursor_show(void)
 {
+    if (g_headless) return;   /* see cursor_hide() */
     const char *ttys[] = { "/dev/tty0", "/dev/tty1", "/dev/tty", "/dev/console", NULL };
     for (int i = 0; ttys[i]; i++) {
         int fd = open(ttys[i], O_RDWR | O_NONBLOCK);
@@ -451,8 +464,20 @@ static int device_is_mister_virtual(const char *name)
  * skips any /dev/input/eventN already tracked, only opening ones that are
  * new since the last call (a reconnected wireless pad, for example, can
  * come back as a fresh node with a different number). */
+static void stdin_input_open(void);   /* forward decls — desktop backends, defined below */
+static void script_open(void);
+static void stdin_input_restore(void);
+static void stdin_input_drain(void);
+
 static void input_open(void)
 {
+    /* Desktop backends come up alongside (not instead of) evdev — both are
+     * no-ops unless their own env var asked for them, so this stays exactly
+     * the old behavior on real hardware. Safe to call repeatedly, same as
+     * the evdev scan below (see this function's own header comment). */
+    if (getenv("MISTERFIN_STDIN")) stdin_input_open();
+    script_open();
+
     DIR *d = opendir("/dev/input");
     if (!d) return;
     struct dirent *e;
@@ -479,25 +504,245 @@ static void input_open(void)
     closedir(d);
 }
 
+static void input_repeat_reset(void);   /* forward decl — defined with the repeat logic below */
+
 static void input_drain(void)
 {
     struct input_event ev;
     for (int i = 0; i < input_count; i++)
         while (read(input_fds[i], &ev, sizeof(ev)) == (ssize_t)sizeof(ev)) {}
+    input_repeat_reset();
+    stdin_input_drain();
 }
 
 static void input_close(void)
 {
     for (int i = 0; i < input_count; i++) close(input_fds[i]);
     input_count = 0;
+    stdin_input_restore();
+}
+
+/* ── desktop keyboard backend (stdin, raw mode) ──────────────────────────
+ * Off-hardware there are no /dev/input/eventN gamepads to read, so the same
+ * INP_* masks are sourced from the controlling terminal instead. Enabled by
+ * MISTERFIN_STDIN=1 (interactive) or implicitly by MISTERFIN_KEYS (scripted,
+ * below) — never on the MiSTer, where the evdev path above is the real one.
+ *
+ * Terminals do their own key repeat when a key is held, so this backend gets
+ * auto-repeat for free and doesn't participate in the evdev held-state
+ * repeat logic. */
+static int  stdin_enabled = 0;
+static struct termios stdin_saved_termios;
+static int  stdin_termios_saved = 0;
+
+static void stdin_input_restore(void)
+{
+    if (!stdin_termios_saved) return;
+    tcsetattr(STDIN_FILENO, TCSANOW, &stdin_saved_termios);
+    stdin_termios_saved = 0;
+}
+
+static void stdin_input_open(void)
+{
+    if (stdin_enabled || !isatty(STDIN_FILENO)) return;
+    if (tcgetattr(STDIN_FILENO, &stdin_saved_termios) != 0) return;
+
+    struct termios raw = stdin_saved_termios;
+    raw.c_lflag &= ~(unsigned)(ICANON | ECHO);   /* byte-at-a-time, no local echo */
+    raw.c_cc[VMIN]  = 0;                          /* fully non-blocking reads */
+    raw.c_cc[VTIME] = 0;
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) != 0) return;
+
+    stdin_termios_saved = 1;
+    stdin_enabled       = 1;
+    atexit(stdin_input_restore);   /* also covers the on_fatal/_exit paths' terminal state */
+    fcntl(STDIN_FILENO, F_SETFL, fcntl(STDIN_FILENO, F_GETFL, 0) | O_NONBLOCK);
+}
+
+/* Discards buffered keystrokes typed while a blocking operation was running,
+ * matching what input_drain() does for the evdev queues. Scripted playback
+ * is deliberately unaffected — it's paced off the wall clock rather than
+ * buffered, so there's nothing to drop. */
+static void stdin_input_drain(void)
+{
+    if (!stdin_enabled) return;
+    unsigned char buf[64];
+    while (read(STDIN_FILENO, buf, sizeof(buf)) > 0) {}
+}
+
+/* Maps one already-decoded terminal key to an INP_* bit. Escape sequences
+ * (arrows, PageUp/Down, Home) are decoded by the caller and passed in as the
+ * synthetic codes below, which are deliberately outside the ASCII range so
+ * they can't collide with a real typed character. */
+#define TK_UP     0x100
+#define TK_DOWN   0x101
+#define TK_LEFT   0x102
+#define TK_RIGHT  0x103
+#define TK_PGUP   0x104
+#define TK_PGDN   0x105
+#define TK_HOME   0x106
+#define TK_ESC    0x107
+
+static int stdin_key_to_mask(int key)
+{
+    switch (key) {
+    case TK_UP:                 return INP_UP;
+    case TK_DOWN:               return INP_DOWN;
+    case TK_LEFT:               return INP_LEFT;
+    case TK_RIGHT:              return INP_RIGHT;
+    /* Same pairing the evdev path uses: Enter/X confirm, Esc/Z back. */
+    case '\r': case '\n':
+    case 'x': case 'X':         return INP_A;
+    case TK_ESC:
+    case 0x7f: case '\b':
+    case 'z': case 'Z':         return INP_B;
+    case '\t':                  return INP_SELECT;
+    case TK_HOME: case 'p':     return INP_START;
+    case TK_PGUP: case '[':     return INP_L;
+    case TK_PGDN: case ']':     return INP_R;
+    default:                    return 0;
+    }
+}
+
+/* Decodes whatever bytes are pending on stdin into an INP_* mask. 'q' quits
+ * outright — there's no window manager to close off-hardware, and Esc is
+ * already spoken for as "back". */
+static int stdin_poll(void)
+{
+    if (!stdin_enabled) return 0;
+
+    unsigned char buf[64];
+    ssize_t n = read(STDIN_FILENO, buf, sizeof(buf));
+    if (n <= 0) return 0;
+
+    int mask = 0;
+    for (ssize_t i = 0; i < n; i++) {
+        int key = buf[i];
+        if (key == 'q') { g_running = 0; continue; }
+
+        /* CSI sequences arrive as one contiguous burst in the same read, so
+         * looking ahead within this buffer is enough — a bare ESC (nothing
+         * following it) is a real Esc keypress. */
+        if (key == 0x1b) {
+            if (i + 2 < n && buf[i + 1] == '[') {
+                unsigned char c = buf[i + 2];
+                i += 2;
+                switch (c) {
+                case 'A': key = TK_UP;    break;
+                case 'B': key = TK_DOWN;  break;
+                case 'C': key = TK_RIGHT; break;
+                case 'D': key = TK_LEFT;  break;
+                case 'H': key = TK_HOME;  break;
+                /* "5~"/"6~"/"1~" — swallow the trailing '~' too */
+                case '5': key = TK_PGUP; if (i + 1 < n && buf[i+1] == '~') i++; break;
+                case '6': key = TK_PGDN; if (i + 1 < n && buf[i+1] == '~') i++; break;
+                case '1': key = TK_HOME; if (i + 1 < n && buf[i+1] == '~') i++; break;
+                default:  continue;   /* some other CSI sequence — ignore it */
+                }
+            } else {
+                key = TK_ESC;
+            }
+        }
+        mask |= stdin_key_to_mask(key);
+    }
+    return mask;
+}
+
+/* ── scripted key playback (MISTERFIN_KEYS) ──────────────────────────────
+ * A comma-separated list of key names, each optionally followed by ":<ms>"
+ * for how long to wait after it before the next one (default SCRIPT_STEP_MS)
+ * — e.g. MISTERFIN_KEYS="right,right,a:800,down,down".
+ *
+ * Reproducible screenshots without a human at the keyboard: pair it with
+ * MISTERFIN_FRAME_OUT and the raw file holds whatever was on screen when the
+ * script finished. The app quits once the queue drains (that's the point —
+ * it's for automation), unless MISTERFIN_KEYS_HOLD=1 asks it to stay up. */
+#define SCRIPT_MAX      256
+#define SCRIPT_STEP_MS  400
+
+typedef struct { int mask; int delay_ms; } ScriptKey;
+static ScriptKey script_keys[SCRIPT_MAX];
+static int    script_count = 0, script_pos = 0;
+static double script_next_at = 0.0;
+static int    script_hold = 0;
+
+static int script_name_to_mask(const char *name)
+{
+    if (!strcmp(name, "up"))     return INP_UP;
+    if (!strcmp(name, "down"))   return INP_DOWN;
+    if (!strcmp(name, "left"))   return INP_LEFT;
+    if (!strcmp(name, "right"))  return INP_RIGHT;
+    if (!strcmp(name, "a"))      return INP_A;
+    if (!strcmp(name, "b"))      return INP_B;
+    if (!strcmp(name, "select")) return INP_SELECT;
+    if (!strcmp(name, "start"))  return INP_START;
+    if (!strcmp(name, "l"))      return INP_L;
+    if (!strcmp(name, "r"))      return INP_R;
+    if (!strcmp(name, "wait"))   return 0;   /* pure delay, no button */
+    fprintf(stderr, "MISTERFIN_KEYS: unknown key \"%s\"\n", name);
+    return 0;
+}
+
+/* input_open() re-runs every few seconds to pick up hotplugged pads, so this
+ * has to be idempotent — without the latch, each rescan would re-parse the
+ * script and rewind it to the start, looping forever. */
+static void script_open(void)
+{
+    static int script_loaded = 0;
+    if (script_loaded) return;
+    script_loaded = 1;
+
+    const char *spec = getenv("MISTERFIN_KEYS");
+    if (!spec || !*spec) return;
+    const char *hold = getenv("MISTERFIN_KEYS_HOLD");
+    script_hold = (hold && *hold && strcmp(hold, "0") != 0);
+
+    char list[1024];
+    strncpy(list, spec, sizeof(list) - 1);
+    list[sizeof(list) - 1] = '\0';
+
+    for (char *tok = strtok(list, ","); tok && script_count < SCRIPT_MAX;
+         tok = strtok(NULL, ",")) {
+        while (*tok == ' ') tok++;
+        int delay = SCRIPT_STEP_MS;
+        char *colon = strchr(tok, ':');
+        if (colon) { *colon = '\0'; delay = atoi(colon + 1); }
+        script_keys[script_count].mask     = script_name_to_mask(tok);
+        script_keys[script_count].delay_ms = delay > 0 ? delay : SCRIPT_STEP_MS;
+        script_count++;
+    }
+    /* First key fires after one step, so the startup fetch has a moment to
+     * land before the script starts pressing things. */
+    if (script_count > 0) script_next_at = now_sec() + SCRIPT_STEP_MS / 1000.0;
+}
+
+static int script_poll(void)
+{
+    if (script_count == 0) return 0;
+    double t = now_sec();
+    if (t < script_next_at) return 0;
+
+    if (script_pos >= script_count) {
+        if (!script_hold) g_running = 0;
+        return 0;
+    }
+    ScriptKey *k = &script_keys[script_pos++];
+    script_next_at = t + k->delay_ms / 1000.0;
+    return k->mask;
 }
 
 static int input_poll(void)
 {
     struct input_event ev;
-    int mask = 0;
+    int mask = stdin_poll() | script_poll();
     for (int i = 0; i < input_count; i++) {
         while (read(input_fds[i], &ev, sizeof(ev)) == (ssize_t)sizeof(ev)) {
+            /* Press edges only. Releases don't need tracking here: auto-repeat
+             * reads the device's real current state instead of reconstructing
+             * it from edges (see input_repeat). The kernel's own key repeat
+             * (value 2) is ignored too — it only fires for real keyboards,
+             * never for a gamepad button or D-pad hat, and runs at whatever
+             * rate the console is configured for. */
             if (ev.type == EV_KEY && ev.value == 1) {
                 int code = ev.code;
                 if (input_swap_ab[i]) {
@@ -521,28 +766,30 @@ static int input_poll(void)
                     code != KEY_ENTER && code != KEY_ESC && code != KEY_BACK) {
                     continue;
                 }
+                int bit = 0;
                 switch (code) {
-                case BTN_EAST:               mask |= INP_A;      break;
-                case BTN_SOUTH:              mask |= INP_B;      break;
+                case BTN_EAST:               bit = INP_A;      break;
+                case BTN_SOUTH:              bit = INP_B;      break;
                 /* Enter/Esc are the intuitive confirm/cancel pair; X/Z are
                  * the de facto SNES-emulator standard (RetroArch/SNES9x
                  * default keyboard mapping) matching the SNES pad's A
                  * (right) / B (bottom) positions — both work. */
                 case KEY_ENTER:
-                case KEY_X:                  mask |= INP_A;      break;
+                case KEY_X:                  bit = INP_A;      break;
                 case KEY_ESC:
                 case KEY_BACK:
                 case KEY_BACKSPACE:
-                case KEY_Z:                  mask |= INP_B;      break;
-                case BTN_START: case KEY_PAUSE: case KEY_HOME: mask |= INP_START;  break;
-                case BTN_SELECT: case KEY_TAB:  mask |= INP_SELECT; break;
-                case KEY_UP:                     mask |= INP_UP;    break;
-                case KEY_DOWN:                   mask |= INP_DOWN;  break;
-                case KEY_LEFT:                   mask |= INP_LEFT;  break;
-                case KEY_RIGHT:                  mask |= INP_RIGHT; break;
-                case BTN_TL: case KEY_PAGEUP:    mask |= INP_L;     break;
-                case BTN_TR: case KEY_PAGEDOWN:  mask |= INP_R;     break;
+                case KEY_Z:                  bit = INP_B;      break;
+                case BTN_START: case KEY_PAUSE: case KEY_HOME: bit = INP_START;  break;
+                case BTN_SELECT: case KEY_TAB:  bit = INP_SELECT; break;
+                case KEY_UP:                     bit = INP_UP;    break;
+                case KEY_DOWN:                   bit = INP_DOWN;  break;
+                case KEY_LEFT:                   bit = INP_LEFT;  break;
+                case KEY_RIGHT:                  bit = INP_RIGHT; break;
+                case BTN_TL: case KEY_PAGEUP:    bit = INP_L;     break;
+                case BTN_TR: case KEY_PAGEDOWN:  bit = INP_R;     break;
                 }
+                mask |= bit;
             } else if (ev.type == EV_ABS) {
                 if (ev.code == ABS_HAT0Y) {
                     if (ev.value == -1) mask |= INP_UP;
@@ -558,10 +805,137 @@ static int input_poll(void)
     return mask;
 }
 
+/* ── navigation auto-repeat ──────────────────────────────────────────────────
+ * Holding a direction should keep scrolling instead of demanding one press
+ * per row — a library of any size was otherwise a genuine repetitive-strain
+ * hazard to get through.
+ *
+ * Deliberately NOT folded into input_poll()'s return value: repeats are only
+ * wanted where the action is "move a cursor". Applying them everywhere would
+ * make a held UP skip through music tracks at ten a second on the now-playing
+ * screen, and a held LEFT pile up an enormous accumulated video seek. Callers
+ * that want repeat OR this in explicitly; everything else keeps seeing clean
+ * press edges only.
+ *
+ * Two rates: a slower one to start with (so a deliberate single-row nudge
+ * doesn't overshoot), then faster once it's clear the direction is being held
+ * on purpose, which is what makes crossing a few hundred rows bearable. */
+#define REPEAT_DELAY_SEC  0.35   /* hold this long before repeating at all */
+#define REPEAT_SLOW_SEC   0.11
+#define REPEAT_FAST_SEC   0.045
+#define REPEAT_RAMP_AFTER 6      /* repeats at the slow rate before speeding up */
+
+static int    repeat_mask  = 0;      /* direction currently repeating, 0 = none */
+static double repeat_next  = 0.0;
+static int    repeat_count = 0;
+static int    repeat_suppressed = 0; /* see input_repeat_reset */
+
+static void input_repeat_reset(void)
+{
+    repeat_mask  = 0;
+    repeat_next  = 0.0;
+    repeat_count = 0;
+    /* Called from input_drain, i.e. right after a screen change. Whatever is
+     * physically held at that moment shouldn't immediately start scrolling
+     * the screen you just arrived at, so repeat stays parked until the user
+     * lets go of everything. */
+    repeat_suppressed = 1;
+}
+
+/* Bit-array helpers for the evdev state ioctls below (linux/input.h returns
+ * these as an array of unsigned long). */
+#define INPUT_BITS_PER_LONG  (8 * (int)sizeof(unsigned long))
+#define INPUT_NLONGS(n)      (((n) + INPUT_BITS_PER_LONG - 1) / INPUT_BITS_PER_LONG)
+#define INPUT_TEST_BIT(arr, bit) \
+    ((arr)[(bit) / INPUT_BITS_PER_LONG] & (1UL << ((bit) % INPUT_BITS_PER_LONG)))
+
+/* Asks each device what it is ACTUALLY holding right now, via EVIOCGKEY /
+ * EVIOCGABS, rather than reconstructing it from the press/release stream.
+ *
+ * This is a correctness fix, not an optimisation. Reconstructing held state
+ * from edges means a single missed release leaves a direction stuck "down"
+ * forever — which showed up on hardware as auto-repeat that wouldn't stop
+ * until the button was pressed again. There are several ways to miss one
+ * here: input_drain() deliberately discards pending events at every screen
+ * change, a hotplugged pad can be reopened under a new event node mid-press
+ * leaving a stale entry nothing ever clears, and MiSTer's OSD echoes pad
+ * input onto a second virtual device whose event pairing this code does not
+ * control. Reading the state directly makes all of those unrepresentable:
+ * there is no accumulated state to go wrong, and a device that has gone away
+ * simply fails the ioctl and contributes nothing. */
+static int input_nav_held(void)
+{
+    int mask = 0;
+    for (int i = 0; i < input_count; i++) {
+        unsigned long keys[INPUT_NLONGS(KEY_MAX + 1)];
+        memset(keys, 0, sizeof(keys));
+        if (ioctl(input_fds[i], EVIOCGKEY(sizeof(keys)), keys) >= 0) {
+            if (INPUT_TEST_BIT(keys, KEY_UP))    mask |= INP_UP;
+            if (INPUT_TEST_BIT(keys, KEY_DOWN))  mask |= INP_DOWN;
+            if (INPUT_TEST_BIT(keys, KEY_LEFT))  mask |= INP_LEFT;
+            if (INPUT_TEST_BIT(keys, KEY_RIGHT)) mask |= INP_RIGHT;
+        }
+        /* D-pads arrive as a hat axis rather than as keys. A device without
+         * these axes just fails the ioctl or reports 0, both of which mean
+         * "nothing held" — no need to probe capabilities first. */
+        struct input_absinfo abs;
+        if (ioctl(input_fds[i], EVIOCGABS(ABS_HAT0Y), &abs) >= 0) {
+            if (abs.value < 0) mask |= INP_UP;
+            if (abs.value > 0) mask |= INP_DOWN;
+        }
+        if (ioctl(input_fds[i], EVIOCGABS(ABS_HAT0X), &abs) >= 0) {
+            if (abs.value < 0) mask |= INP_LEFT;
+            if (abs.value > 0) mask |= INP_RIGHT;
+        }
+    }
+    return mask;
+}
+
+/* Returns the nav bits that should act as though freshly pressed this tick
+ * because they're being held down. Call once per main-loop iteration. */
+static int input_repeat(void)
+{
+    int held = input_nav_held();
+
+    if (repeat_suppressed) {
+        if (held) return 0;      /* still held over from before the screen change */
+        repeat_suppressed = 0;   /* released — normal service resumes */
+    }
+
+    double t = now_sec();
+
+    /* Any change in which direction is held restarts the delay — including
+     * releasing one of two simultaneously held directions, which is the
+     * right call: the surviving direction is then effectively a new press. */
+    if (held != repeat_mask) {
+        repeat_mask  = held;
+        repeat_count = 0;
+        repeat_next  = held ? t + REPEAT_DELAY_SEC : 0.0;
+        return 0;
+    }
+    if (!held || t < repeat_next) return 0;
+
+    repeat_next = t + (repeat_count >= REPEAT_RAMP_AFTER ? REPEAT_FAST_SEC : REPEAT_SLOW_SEC);
+    repeat_count++;
+    return held;
+}
+
 /* ── app state ────────────────────────────────────────────────────────────── */
 
-typedef enum { STATE_CONFIG_ERROR, STATE_BROWSE, STATE_INFO, STATE_PLAYING, STATE_PLAYING_AUDIO } AppState;
-typedef enum { FRAME_VIEWS, FRAME_ITEMS, FRAME_SEASONS, FRAME_EPISODES } FrameKind;
+typedef enum {
+    STATE_CONFIG_ERROR, STATE_QUICK_CONNECT,
+    STATE_BROWSE, STATE_INFO, STATE_PLAYING, STATE_PLAYING_AUDIO
+} AppState;
+typedef enum {
+    FRAME_VIEWS, FRAME_ITEMS, FRAME_SEASONS, FRAME_EPISODES,
+    FRAME_RESUME,   /* Continue Watching — see JF_VIEW_RESUME */
+    FRAME_NEXTUP    /* Next Up          — see JF_VIEW_NEXTUP */
+} FrameKind;
+
+/* Rows fetched for each home row. Both are "what to watch next" lists rather
+ * than libraries to browse — past a couple of screenfuls nobody scrolls, so
+ * they're capped instead of paginated. */
+#define HOME_ROW_MAX 24
 
 #define MAX_STACK 8
 
@@ -580,6 +954,18 @@ static int         g_stack_depth = 0;
 static JfItem g_items[JF_MAX_ITEMS];
 static int    g_item_count = 0;
 static int    g_sel = 0, g_scroll = 0;
+/* g_items[] holds one window of the current frame's list rather than the
+ * whole thing — libraries can be far larger than any buffer we'd want to
+ * keep resident, and the previous fixed Limit=JF_MAX_ITEMS silently
+ * presented a truncated library as if it were complete.
+ *
+ * g_window_start is the absolute index of g_items[0]; g_sel and g_scroll
+ * stay window-relative (so every existing g_items[g_sel] use is unchanged),
+ * and absolute position is g_window_start + g_sel. g_total_count is the
+ * server's TotalRecordCount, or -1 when unknown — in which case the loaded
+ * window is all there is, as far as anything here can tell. */
+static int    g_window_start = 0;
+static int64_t g_total_count = -1;
 static double g_marquee_px = 0.0;         /* scroll offset for an over-long title, see draw_browse */
 static char   g_marquee_title[128] = "";  /* last title drawn — reset the offset when it changes */
 /* Per-library item counts for the root carousel (see draw_browse_carousel),
@@ -588,15 +974,6 @@ static char   g_marquee_title[128] = "";  /* last title drawn — reset the offs
  * (3 small Limit=0 count requests for this user's library, one per view).
  * -1 = fetch failed, caller just omits the count line for that card. */
 static int64_t g_view_counts[JF_MAX_ITEMS];
-/* Episode count per row, parallel to g_items[], only meaningful for
- * JF_TYPE_SERIES rows in a FRAME_ITEMS listing (a TV library's series
- * list) — fetched alongside the listing itself in fetch_frame(). Season
- * count needs no such array: it's it->child_count, already free on the
- * same request (confirmed on a real server that a Series' ChildCount is
- * its season count, unlike a top-level library view's — see
- * jf_count_items's own comment for that distinction). -1 = fetch failed or
- * not a series, caller omits the episode part of the line. */
-static int64_t g_series_episode_counts[JF_MAX_ITEMS];
 /* Root screen (FRAME_VIEWS) rendering mode — 0 = carousel (default),
  * 1 = classic list, toggled by SELECT (see the STATE_BROWSE input handling
  * below). Persists for the whole app session, not just this one visit to
@@ -795,30 +1172,137 @@ static const char *collection_item_type(const char *collection_type)
     return NULL;
 }
 
-static void fetch_frame(void)
+/* The two home rows are presented as extra cards on the library carousel, but
+ * they aren't libraries — no ParentId to list, no collection type, and their
+ * contents change every time something is watched. Everything that would
+ * normally reach for the server via a view id has to route around them. */
+static int view_is_resume(const JfItem *v) { return !strcmp(v->id, JF_VIEW_RESUME); }
+static int view_is_nextup(const JfItem *v) { return !strcmp(v->id, JF_VIEW_NEXTUP); }
+static int view_is_synthetic(const JfItem *v) { return view_is_resume(v) || view_is_nextup(v); }
+
+/* Episodes in these rows arrive out of context — the row mixes shows, so a
+ * name like "Episode 03" identifies nothing. Fold the series name and season/
+ * episode numbers into the display name, which keeps draw_browse unchanged
+ * (it just draws whatever name it's given). The info screen re-fetches by id
+ * and so still shows the clean title. */
+static void home_row_label_episodes(void)
+{
+    for (int i = 0; i < g_item_count; i++) {
+        JfItem *it = &g_items[i];
+        if (it->type != JF_TYPE_EPISODE || !it->series_name[0]) continue;
+
+        char combined[JF_NAME_LEN];
+        if (it->parent_index_number > 0 && it->index_number > 0)
+            snprintf(combined, sizeof(combined), "%s - S%dE%02d %s",
+                     it->series_name, it->parent_index_number, it->index_number, it->name);
+        else
+            snprintf(combined, sizeof(combined), "%s - %s", it->series_name, it->name);
+
+        strncpy(it->name, combined, sizeof(it->name) - 1);
+        it->name[sizeof(it->name) - 1] = '\0';
+    }
+}
+
+/* Loads the window of the current frame's list that starts at start_index.
+ * Only the list itself moves — the frame stack, and which frame is current,
+ * are untouched, so this is equally the "open this frame" path (start 0) and
+ * the "scroll past the end of what's loaded" path. */
+static void fetch_frame_window(int start_index)
 {
     BrowseFrame *f = &g_stack[g_stack_depth - 1];
+    if (start_index < 0) start_index = 0;
+
+    g_window_start = start_index;
+    g_total_count  = -1;
+
     switch (f->kind) {
-    case FRAME_VIEWS:
-        g_item_count = jf_list_views(&g_cfg, g_items, JF_MAX_ITEMS);
-        for (int i = 0; i < g_item_count; i++) {
-            const char *item_type = collection_item_type(g_items[i].collection_type);
-            g_view_counts[i] = jf_count_items(&g_cfg, g_items[i].id, item_type);
+    case FRAME_VIEWS: {
+        /* Library views are a handful of entries by definition — no paging. */
+        g_window_start = 0;
+
+        /* Continue Watching and Next Up go in front of the real libraries:
+         * they're what someone opening the app usually wants, and putting
+         * them first means the carousel starts there. Each is added only when
+         * it actually has something in it — an empty "Continue Watching" card
+         * is worse than no card, and both are empty on a fresh install.
+         *
+         * Probed with Limit=1 rather than fetched in full: all that's needed
+         * here is the count for the card, and drilling in re-fetches anyway. */
+        /* Card labels are short because the carousel draws them at double
+         * size and clips to CAROUSEL_CARD_W — "Continue Watching" came out as
+         * "Continue...". The full name is used for the frame title once you
+         * drill in (see the STATE_BROWSE handler), where there's room. */
+        int n_synth = 0;
+        static const struct { const char *id, *name; } synth[] = {
+            { JF_VIEW_RESUME, "Continue" },
+            { JF_VIEW_NEXTUP, "Next Up" },
+        };
+        for (int s = 0; s < 2; s++) {
+            JfItem probe[1];
+            int64_t total = 0;
+            int got = (s == 0) ? jf_list_resume(&g_cfg, probe, 1, &total)
+                                : jf_list_nextup(&g_cfg, probe, 1, &total);
+            if (got <= 0) continue;
+            if (total <= 0) total = got;
+
+            JfItem *card = &g_items[n_synth];
+            memset(card, 0, sizeof(*card));
+            strncpy(card->id,   synth[s].id,   sizeof(card->id) - 1);
+            strncpy(card->name, synth[s].name, sizeof(card->name) - 1);
+            card->type = JF_TYPE_FOLDER;
+            card->index_number = -1;
+            g_view_counts[n_synth] = total;
+            n_synth++;
         }
+
+        int n_views = jf_list_views(&g_cfg, g_items + n_synth, JF_MAX_ITEMS - n_synth);
+        for (int i = 0; i < n_views; i++) {
+            JfItem *v = &g_items[n_synth + i];
+            g_view_counts[n_synth + i] =
+                jf_count_items(&g_cfg, v->id, collection_item_type(v->collection_type));
+        }
+        g_item_count = n_synth + n_views;
+        break;
+    }
+    case FRAME_RESUME:
+        g_window_start = 0;
+        g_item_count = jf_list_resume(&g_cfg, g_items, HOME_ROW_MAX, &g_total_count);
+        home_row_label_episodes();
+        break;
+    case FRAME_NEXTUP:
+        g_window_start = 0;
+        g_item_count = jf_list_nextup(&g_cfg, g_items, HOME_ROW_MAX, &g_total_count);
+        home_row_label_episodes();
         break;
     case FRAME_ITEMS:
-        g_item_count = jf_list_items(&g_cfg, f->parent_id, g_items, JF_MAX_ITEMS);
-        for (int i = 0; i < g_item_count; i++)
-            g_series_episode_counts[i] = (g_items[i].type == JF_TYPE_SERIES)
-                ? jf_count_items(&g_cfg, g_items[i].id, "Episode") : -1;
+        /* Episode counts for series rows used to be fetched here with one
+         * extra recursive count request PER ROW — so opening a 200-series
+         * TV library meant 200 sequential curl invocations before anything
+         * could be drawn. They now ride along on the listing itself as
+         * RecursiveItemCount, which the server computes for the whole
+         * result set in a single batched query. See JfItem's own comment. */
+        g_item_count = jf_list_items(&g_cfg, f->parent_id, start_index,
+                                      g_items, JF_PAGE_SIZE, &g_total_count);
         break;
     case FRAME_SEASONS:
+        g_window_start = 0;   /* a series' season list is always short */
         g_item_count = jf_list_seasons(&g_cfg, f->series_id, g_items, JF_MAX_ITEMS);
         break;
     case FRAME_EPISODES:
-        g_item_count = jf_list_episodes(&g_cfg, f->series_id, f->season_id, g_items, JF_MAX_ITEMS);
+        g_item_count = jf_list_episodes(&g_cfg, f->series_id, f->season_id, start_index,
+                                         g_items, JF_PAGE_SIZE, &g_total_count);
         break;
     }
+    /* No TotalRecordCount came back (older server, or an endpoint that
+     * doesn't report one) — treat what's loaded as the whole list, which is
+     * the pre-pagination behavior and degrades safely. */
+    if (g_total_count < 0) g_total_count = g_window_start + g_item_count;
+}
+
+static void fetch_frame(void)
+{
+    fetch_frame_window(0);
+    BrowseFrame *f = &g_stack[g_stack_depth - 1];
     g_sel = 0; g_scroll = 0;
     /* Returning to the root screen (B all the way back out of a library)
      * should land on whichever library you drilled into, not always snap
@@ -899,6 +1383,50 @@ static int visible_rows(FBDev *fb)
      * NTSC, using it directly here reclaims that space as an extra visible
      * row instead of leaving it as unused slack. */
     return (fb->height - (8 + SAFE_Y_BOT) - (SAFE_Y + 24)) / ROW_H;
+}
+
+/* Moves the browse-list cursor by delta rows, clamping to the list and
+ * pulling the scroll window along with it. Single-stepping (UP/DOWN) and
+ * whole-page jumps (LEFT/RIGHT, L/R) are the same operation with a different
+ * delta, so they share this rather than each maintaining g_scroll their own
+ * way. Returns 1 if anything actually moved.
+ *
+ * Movement is computed in ABSOLUTE list coordinates, so it doesn't care
+ * whether the destination happens to be in the currently loaded window — if
+ * it isn't, the window is re-fetched around it first. Windows are aligned to
+ * JF_PAGE_SIZE boundaries rather than centred on the cursor so that scrolling
+ * back and forth across one boundary can't thrash a re-fetch per row. */
+static int browse_move_sel(FBDev *fb, int delta)
+{
+    if (delta == 0) return 0;
+
+    int total = (int)g_total_count;
+    if (total <= 0) total = g_item_count;
+    if (total <= 0) return 0;
+
+    int abs_sel = g_window_start + g_sel;
+    int new_abs = abs_sel + delta;
+    if (new_abs < 0) new_abs = 0;
+    if (new_abs > total - 1) new_abs = total - 1;
+    if (new_abs == abs_sel) return 0;
+
+    if (new_abs < g_window_start || new_abs >= g_window_start + g_item_count) {
+        fetch_frame_window((new_abs / JF_PAGE_SIZE) * JF_PAGE_SIZE);
+        g_scroll = 0;   /* old window's scroll offset means nothing now */
+        if (g_item_count <= 0) return 0;   /* fetch failed — leave the cursor put */
+        if (new_abs >= g_window_start + g_item_count)
+            new_abs = g_window_start + g_item_count - 1;
+    }
+
+    g_sel = new_abs - g_window_start;
+
+    int vis = visible_rows(fb);
+    if (g_sel < g_scroll)              g_scroll = g_sel;
+    if (g_sel >= g_scroll + vis)       g_scroll = g_sel - vis + 1;
+    if (g_scroll > g_item_count - vis) g_scroll = g_item_count - vis;
+    if (g_scroll < 0)                  g_scroll = 0;
+
+    return 1;
 }
 
 /* Simple "flying through stars" background for the About screen — each
@@ -1524,6 +2052,163 @@ static void draw_setup_screen(FBDev *fb, const char *reason)
     fb_flip(fb);
 }
 
+/* ── Quick Connect ────────────────────────────────────────────────────────── */
+
+typedef enum {
+    QC_STARTING,     /* asking the server to open a request */
+    QC_WAITING,      /* code on screen, waiting for the user to approve it */
+    QC_AUTHENTICATED,
+    QC_UNAVAILABLE,  /* server has Quick Connect switched off */
+    QC_FAILED        /* request expired, denied, or the server went away */
+} QcState;
+
+static pthread_mutex_t g_qc_mutex = PTHREAD_MUTEX_INITIALIZER;
+static QcState  g_qc_state = QC_STARTING;
+static char     g_qc_code[16] = "";
+
+static QcState qc_get_state(char *code_out, int code_len)
+{
+    pthread_mutex_lock(&g_qc_mutex);
+    QcState s = g_qc_state;
+    if (code_out) {
+        strncpy(code_out, g_qc_code, (size_t)code_len - 1);
+        code_out[code_len - 1] = '\0';
+    }
+    pthread_mutex_unlock(&g_qc_mutex);
+    return s;
+}
+
+static void qc_set_state(QcState s)
+{
+    pthread_mutex_lock(&g_qc_mutex);
+    g_qc_state = s;
+    pthread_mutex_unlock(&g_qc_mutex);
+}
+
+/* Runs the whole handshake off the main thread: the polling below waits on a
+ * person walking to another device, which can be minutes. Blocking the main
+ * loop for that would freeze the starfield and stop the screen responding to
+ * a cancel press. */
+#define QC_POLL_INTERVAL_SEC 3
+#define QC_TIMEOUT_SEC       300
+
+static void *quick_connect_thread(void *arg)
+{
+    (void)arg;
+
+    if (!jf_quick_connect_enabled(&g_cfg)) { qc_set_state(QC_UNAVAILABLE); return NULL; }
+
+    JfQuickConnect qc;
+    if (!jf_quick_connect_initiate(&g_cfg, &qc)) { qc_set_state(QC_FAILED); return NULL; }
+
+    pthread_mutex_lock(&g_qc_mutex);
+    strncpy(g_qc_code, qc.code, sizeof(g_qc_code) - 1);
+    g_qc_state = QC_WAITING;
+    pthread_mutex_unlock(&g_qc_mutex);
+
+    int elapsed = 0, consecutive_errors = 0;
+    while (elapsed < QC_TIMEOUT_SEC && g_running) {
+        sleep(QC_POLL_INTERVAL_SEC);
+        elapsed += QC_POLL_INTERVAL_SEC;
+
+        int poll = jf_quick_connect_poll(&g_cfg, &qc);
+        if (poll == 1) break;
+        if (poll < 0) {
+            /* A poll failure is ambiguous — the request really being gone
+             * looks the same as the wifi hiccupping. Tolerate a couple before
+             * concluding the request is dead, so a blip doesn't throw away a
+             * code the user is halfway through typing. */
+            if (++consecutive_errors >= 3) { qc_set_state(QC_FAILED); return NULL; }
+        } else {
+            consecutive_errors = 0;
+        }
+    }
+    if (elapsed >= QC_TIMEOUT_SEC) { qc_set_state(QC_FAILED); return NULL; }
+    if (!g_running) return NULL;
+
+    if (!jf_quick_connect_authenticate(&g_cfg, &qc)) { qc_set_state(QC_FAILED); return NULL; }
+
+    jf_token_save(&g_cfg);   /* so this is a one-time step, not a per-launch one */
+    qc_set_state(QC_AUTHENTICATED);
+    return NULL;
+}
+
+static void draw_quick_connect(FBDev *fb)
+{
+    fb_clear(fb);
+    draw_starfield(fb);
+
+    char code[16];
+    QcState state = qc_get_state(code, sizeof(code));
+
+    const int ts = 2, s1 = 1;
+    const int tch = 8 * ts, sch = 8 * s1, lsp = 6;
+
+    /* Laid out from the vertical centre outwards rather than from the top,
+     * so it sits right at both PAL's 288 lines and NTSC's 240 without a
+     * per-resolution case. */
+    int cur_y = fb->height / 2 - 58;
+
+    static const char title[] = "Quick Connect";
+    draw_text(fb, (fb->width - text_width(fb, title, ts)) / 2, cur_y, title, ts, COL_TITLE);
+    cur_y += tch + lsp * 2;
+
+    switch (state) {
+    case QC_STARTING: {
+        const char *msg = "Contacting server...";
+        draw_text(fb, (fb->width - text_width(fb, msg, s1)) / 2, cur_y, msg, s1, COL_HINT);
+        break;
+    }
+    case QC_WAITING: {
+        const char *l1 = "In Jellyfin, open your user menu and";
+        const char *l2 = "choose Quick Connect, then enter:";
+        draw_text(fb, (fb->width - text_width(fb, l1, s1)) / 2, cur_y, l1, s1, COL_HINT);
+        cur_y += sch + lsp;
+        draw_text(fb, (fb->width - text_width(fb, l2, s1)) / 2, cur_y, l2, s1, COL_HINT);
+        cur_y += sch + lsp * 3;
+
+        /* The code is the one thing being read off a CRT from across a room,
+         * so it gets the largest text on screen by some margin. */
+        draw_text(fb, (fb->width - text_width(fb, code, 3)) / 2, cur_y, code, 3, COL_SEL_FG);
+        cur_y += 8 * 3 + lsp * 3;
+
+        const char *l3 = "Waiting for approval...";
+        draw_text(fb, (fb->width - text_width(fb, l3, s1)) / 2, cur_y, l3, s1, COL_ITEM);
+        break;
+    }
+    case QC_AUTHENTICATED: {
+        const char *msg = "Signed in. Starting...";
+        draw_text(fb, (fb->width - text_width(fb, msg, s1)) / 2, cur_y, msg, s1, COL_WATCHED);
+        break;
+    }
+    case QC_UNAVAILABLE: {
+        const char *l1 = "Quick Connect is disabled on this server.";
+        const char *l2 = "Enable it in Dashboard > General, or put an";
+        const char *l3 = "API key on line 2 of jellyfin.conf.";
+        draw_text(fb, (fb->width - text_width(fb, l1, s1)) / 2, cur_y, l1, s1, COL_ERR);
+        cur_y += sch + lsp * 2;
+        draw_text(fb, (fb->width - text_width(fb, l2, s1)) / 2, cur_y, l2, s1, COL_HINT);
+        cur_y += sch + lsp;
+        draw_text(fb, (fb->width - text_width(fb, l3, s1)) / 2, cur_y, l3, s1, COL_HINT);
+        break;
+    }
+    case QC_FAILED: {
+        const char *l1 = "Quick Connect failed or timed out.";
+        const char *l2 = "B: try again";
+        draw_text(fb, (fb->width - text_width(fb, l1, s1)) / 2, cur_y, l1, s1, COL_ERR);
+        cur_y += sch + lsp * 2;
+        draw_text(fb, (fb->width - text_width(fb, l2, s1)) / 2, cur_y, l2, s1, COL_ITEM);
+        break;
+    }
+    }
+
+    const char *hint = "A: exit";
+    draw_text(fb, (fb->width - text_width(fb, hint, 1)) / 2,
+              fb->height - 8 - SAFE_Y_BOT, hint, 1, COL_HINT);
+
+    fb_flip(fb);
+}
+
 /* NOT a literal aspect-ratio box — blit_fit_centered's 5/3 pixel-aspect
  * correction means a typical portrait poster actually wants a box WIDER
  * than naive square-pixel math would suggest to look right on the real
@@ -1669,7 +2354,9 @@ static void draw_library_card(FBDev *fb, const JfItem *it, int64_t count, int cx
     if (count >= 0) {
         const char *ct = it->collection_type;
         char cbuf[32];
-        if (!strcmp(ct, "movies"))
+        if (view_is_synthetic(it))
+            snprintf(cbuf, sizeof(cbuf), "%lld item%s", (long long)count, count == 1 ? "" : "s");
+        else if (!strcmp(ct, "movies"))
             snprintf(cbuf, sizeof(cbuf), "%lld movie%s", (long long)count, count == 1 ? "" : "s");
         else if (!strcmp(ct, "tvshows"))
             snprintf(cbuf, sizeof(cbuf), "%lld series", (long long)count);
@@ -1866,14 +2553,27 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
                                  const char *dest_path, FBDev *fb_show_ui)
 {
     const char *item_type = collection_item_type(view->collection_type);
-    if (grid_cache_load_from_disk(gc, view, item_type)) {
-        grid_cell_order_shuffle(gc);
-        gc->ready = 1;
-        return;
-    }
-
     JfItem grid_items[GRID_FETCH_MAX];
-    int n = jf_list_items_recursive(&g_cfg, view->id, item_type, grid_items, GRID_FETCH_MAX);
+    int n;
+
+    if (view_is_synthetic(view)) {
+        /* No ParentId to list under — the covers are just the row's own
+         * items. Deliberately not disk-cached either: the whole point of
+         * these rows is that they change as things get watched, so a cache
+         * keyed on a total that barely moves would show stale art for ages
+         * (see grid_cache_load_from_disk's own staleness check). They're only
+         * ever a couple of items, so re-fetching is cheap. */
+        n = view_is_resume(view)
+              ? jf_list_resume(&g_cfg, grid_items, GRID_FETCH_MAX, NULL)
+              : jf_list_nextup(&g_cfg, grid_items, GRID_FETCH_MAX, NULL);
+    } else {
+        if (grid_cache_load_from_disk(gc, view, item_type)) {
+            grid_cell_order_shuffle(gc);
+            gc->ready = 1;
+            return;
+        }
+        n = jf_list_items_recursive(&g_cfg, view->id, item_type, grid_items, GRID_FETCH_MAX);
+    }
 
     int spinner_frame = 0;
     for (int i = 0; i < n && gc->count < GRID_FETCH_MAX; i++) {
@@ -1886,8 +2586,10 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
         }
     }
     grid_cell_order_shuffle(gc);
-    int64_t count = jf_count_items(&g_cfg, view->id, item_type);
-    if (count >= 0) grid_cache_save_to_disk(gc, view->id, count);
+    if (!view_is_synthetic(view)) {
+        int64_t count = jf_count_items(&g_cfg, view->id, item_type);
+        if (count >= 0) grid_cache_save_to_disk(gc, view->id, count);
+    }
     gc->ready = 1;
 }
 
@@ -2191,16 +2893,16 @@ static void draw_browse(FBDev *fb)
                 snprintf(line2, sizeof(line2), "%d album%s",
                          it->child_count, it->child_count == 1 ? "" : "s");
         } else if (it->type == JF_TYPE_SERIES) {
-            /* Season count is it->child_count — free on the same request,
-             * confirmed a Series' own ChildCount means exactly this (unlike
-             * a top-level library view's, see jf_count_items's comment).
-             * Episode count needs its own recursive query per series, done
-             * once in fetch_frame() and cached in g_series_episode_counts. */
-            int64_t ep = g_series_episode_counts[i];
+            /* Both counts ride along on the listing request itself — season
+             * count as ChildCount (confirmed a Series' own ChildCount means
+             * exactly this, unlike a top-level library view's, see
+             * jf_count_items's comment), episode count as RecursiveItemCount.
+             * Neither costs an extra round-trip any more. */
+            int ep = it->recursive_item_count;
             if (it->child_count > 0 && ep > 0)
-                snprintf(line2, sizeof(line2), "%d season%s - %lld episode%s",
+                snprintf(line2, sizeof(line2), "%d season%s - %d episode%s",
                          it->child_count, it->child_count == 1 ? "" : "s",
-                         (long long)ep, ep == 1 ? "" : "s");
+                         ep, ep == 1 ? "" : "s");
             else if (it->child_count > 0)
                 snprintf(line2, sizeof(line2), "%d season%s",
                          it->child_count, it->child_count == 1 ? "" : "s");
@@ -2231,9 +2933,14 @@ static void draw_browse(FBDev *fb)
         }
     }
 
-    if (g_item_count > visible) {
-        char buf[16];
-        snprintf(buf, sizeof(buf), "%d/%d", g_sel+1, g_item_count);
+    /* Absolute position in the whole list, not position within the loaded
+     * window — the window is an implementation detail and showing "3/128"
+     * partway through a 500-item library would be actively misleading. */
+    int64_t total_rows = g_total_count > 0 ? g_total_count : g_item_count;
+    if (total_rows > visible) {
+        char buf[24];
+        snprintf(buf, sizeof(buf), "%d/%lld",
+                 g_window_start + g_sel + 1, (long long)total_rows);
         draw_text(fb, fb->width - text_width(fb, buf,1) - SAFE_X,
                   fb->height - 8 - SAFE_Y_BOT, buf, 1, COL_HINT);
     }
@@ -2523,6 +3230,13 @@ static int     g_current_sub_index = -1;
  * seek-triggered ones, so the burn-in survives seeks the same way
  * g_current_sub_index already does for client-rendered tracks. */
 static int     g_burned_in_sub_index = -1;
+/* -1 = let the server choose the source's default, otherwise the
+ * JfAudioTrack.index baked into the playing stream's URL. Unlike a text
+ * subtitle this can't be switched client-side — the server transcodes one
+ * chosen audio stream into the container it sends, so changing it is a
+ * stream restart (see submenu_confirm). Read by play() on every (re)start so
+ * the choice survives seeks, same as the two subtitle variables above. */
+static int     g_current_audio_index = -1;
 /* Seek is a full stop+restart (network stream isn't byte-range seekable —
  * see player_seek) which takes a couple of seconds; accumulate repeated
  * presses into one seek instead of firing a restart per press, same as
@@ -2668,37 +3382,6 @@ static void player_seek(FBDev *fb, double delta)
  * sub_select in slave mode) and Jellyfin serves the raw .srt directly
  * (confirmed: no transcode needed for a text subtitle codec) — so we just
  * download the chosen track and hand it to mplayer, no restart at all. */
-/* Our bitmap OSD font (same one mplayer's classic subtitle renderer falls
- * back to without FreeType — see -subpos comment in play()) only covers the
- * ASCII range MiSTerDVD's menus ever needed. A downloaded .srt can contain
- * anything — checked a real subtitle file and it was otherwise completely
- * ordinary English text except for a single "♪" (U+266A) used to mark
- * background music with no dialogue — that one non-ASCII character has no
- * glyph in this font and renders as garbage. Blanking any byte >= 0x80
- * drops it (and would drop accented characters in a non-English subtitle
- * too, which is a real loss, but showing garbage is worse and this font
- * can't render them either way). */
-static void sanitize_srt_ascii(const char *path)
-{
-    FILE *f = fopen(path, "r+b");
-    if (!f) return;
-    fseek(f, 0, SEEK_END);
-    long len = ftell(f);
-    if (len <= 0 || len > 2 * 1024 * 1024) { fclose(f); return; }
-    fseek(f, 0, SEEK_SET);
-
-    char *buf = malloc((size_t)len);
-    if (!buf) { fclose(f); return; }
-    size_t got = fread(buf, 1, (size_t)len, f);
-    for (size_t i = 0; i < got; i++)
-        if ((unsigned char)buf[i] >= 0x80) buf[i] = ' ';
-
-    fseek(f, 0, SEEK_SET);
-    fwrite(buf, 1, got, f);
-    fclose(f);
-    free(buf);
-}
-
 /* The .srt has timestamps absolute to the ORIGINAL movie (e.g. 47:32), but
  * mplayer's own clock starts at ~0 for whatever point we asked Jellyfin to
  * start the transcode at (startTimeTicks) — confirmed via the server's own
@@ -2745,7 +3428,7 @@ static void subtitle_load_client(int new_index)
      * selected instead of silently ending up with none. */
     if (!jf_download_subtitle(&g_cfg, g_info_item.id, g_info_item.id, new_index, SUB_LOCAL_PATH))
         return;
-    sanitize_srt_ascii(SUB_LOCAL_PATH);
+    subtitles_sanitize_srt(SUB_LOCAL_PATH);
 
     mp_cmd("pausing_keep sub_remove\n");
     char cmd[112];
@@ -2795,77 +3478,266 @@ static void subtitle_apply(FBDev *fb, int new_index)
     subtitle_load_client(new_index);
 }
 
-/* Cycling with an immediate apply per SELECT press caused a cascade when
- * the old burn-in restart was still in play (each press interrupted the
- * previous restart before it connected, showing as a freeze) — kept the
- * menu even after switching to client-side rendering since a menu is still
- * nicer than blind cycling, though apply is instant now either way. */
+/* Track picker, opened with SELECT during playback.
+ *
+ * Two tabs, because audio and subtitles are genuinely different operations
+ * rather than two lists of the same kind: a text subtitle is rendered
+ * client-side and switches instantly, whereas the audio track is baked into
+ * the server's transcode and switching it costs a stream restart. Splitting
+ * them also keeps each list short enough to fit a 240-line NTSC screen,
+ * which one combined list of up to 17 rows would not.
+ *
+ * Cycling with an immediate apply per SELECT press was tried first and caused
+ * a cascade when a burn-in restart was still in flight (each press interrupted
+ * the previous restart before it connected, showing as a freeze) — hence a
+ * menu with an explicit apply, even though a text-subtitle change is instant. */
+#define SUBMENU_TAB_AUDIO 0
+#define SUBMENU_TAB_SUBS  1
+
 static int    g_submenu_visible    = 0;
-static int    g_submenu_sel        = 0;   /* 0 = Off, i+1 = g_info_item.subs[i] */
+static int    g_submenu_tab        = SUBMENU_TAB_SUBS;
+static int    g_submenu_sub_sel    = 0;   /* 0 = Off, i+1 = g_info_item.subs[i] */
+static int    g_submenu_audio_sel  = 0;   /* index into g_info_item.audio[] */
 static int    g_submenu_was_paused = 0;   /* pause state before the menu opened, to restore on close */
+
+/* Which audio track the server would pick if we said nothing — used to show
+ * a meaningful "current" marker before the user has chosen anything, and as
+ * the starting value for g_current_audio_index. */
+static int default_audio_index(void)
+{
+    for (int i = 0; i < g_info_item.audio_count; i++)
+        if (g_info_item.audio[i].is_default) return g_info_item.audio[i].index;
+    return g_info_item.audio_count > 0 ? g_info_item.audio[0].index : -1;
+}
+
+/* Position in subs[]/audio[] for a given MediaStreams index, or -1.
+ *
+ * These two are NOT interchangeable: stream indices are assigned by the
+ * server across ALL streams of the file, so the first subtitle of a
+ * video+audio+2×subtitle file is index 2, not 0. Conflating them is why the
+ * "currently active" marker used to point at the wrong row (or at no row at
+ * all) for any file whose subtitle streams didn't happen to start at 0. */
+static int sub_pos_for_index(int index)
+{
+    for (int i = 0; i < g_info_item.sub_count; i++)
+        if (g_info_item.subs[i].index == index) return i;
+    return -1;
+}
+
+static int audio_pos_for_index(int index)
+{
+    for (int i = 0; i < g_info_item.audio_count; i++)
+        if (g_info_item.audio[i].index == index) return i;
+    return -1;
+}
+
+/* Rows in the currently shown tab. */
+static int submenu_option_count(void)
+{
+    if (g_submenu_tab == SUBMENU_TAB_AUDIO)
+        return g_info_item.audio_count;      /* no "off" — video always has audio */
+    return g_info_item.sub_count + 1;        /* + "Off" */
+}
+
+/* The frame the menu is drawn over, captured once when it opens.
+ *
+ * draw_submenu runs every tick and composites into fb->back, which is never
+ * otherwise reset — so each frame paints over the last one's leftovers. That
+ * goes unnoticed while the box keeps the same dimensions, but the two tabs
+ * are different sizes (the audio tab has no sync line, and the lists differ
+ * in length), so switching from the taller one left its extra rows stranded
+ * on screen outside the new, shorter box: dead text with nothing behind it.
+ * Restoring this backdrop before each draw makes every frame a clean
+ * composite rather than an accumulation. */
+static uint8_t *g_submenu_bg = NULL;
+static size_t   g_submenu_bg_size = 0;
+
+static void submenu_bg_capture(FBDev *fb)
+{
+    size_t sz = (size_t)fb->stride * fb->height;
+    if (g_submenu_bg_size != sz) {
+        free(g_submenu_bg);
+        g_submenu_bg = malloc(sz);
+        g_submenu_bg_size = g_submenu_bg ? sz : 0;
+    }
+    if (g_submenu_bg) memcpy(g_submenu_bg, fb->mem, sz);
+}
+
+static void submenu_bg_restore(FBDev *fb)
+{
+    if (g_submenu_bg && g_submenu_bg_size == (size_t)fb->stride * fb->height)
+        memcpy(fb->back, g_submenu_bg, g_submenu_bg_size);
+}
 
 static void submenu_open(FBDev *fb)
 {
-    g_submenu_visible    = 1;
-    g_submenu_sel         = g_current_sub_index < 0 ? 0 : g_current_sub_index + 1;
-    g_submenu_was_paused  = g_paused;
+    g_submenu_visible = 1;
+
+    int sub_pos = sub_pos_for_index(g_current_sub_index);
+    g_submenu_sub_sel = (g_current_sub_index < 0 || sub_pos < 0) ? 0 : sub_pos + 1;
+
+    int audio_pos = audio_pos_for_index(g_current_audio_index);
+    g_submenu_audio_sel = audio_pos < 0 ? 0 : audio_pos;
+
+    /* Open on whichever tab is actually useful. Subtitles stay the default
+     * (that's what SELECT has always opened), but on a title with no subtitle
+     * tracks at all and a real choice of audio, opening on an empty list
+     * would look broken. */
+    if (g_info_item.sub_count == 0 && g_info_item.audio_count > 1)
+        g_submenu_tab = SUBMENU_TAB_AUDIO;
+
+    g_submenu_was_paused = g_paused;
     if (!g_paused) player_pause_toggle();
+    submenu_bg_capture(fb);
     memcpy(fb->back, fb->mem, (size_t)fb->stride * fb->height);
 }
 
 static void submenu_close(void)
 {
     g_submenu_visible = 0;
+    free(g_submenu_bg);
+    g_submenu_bg = NULL;
+    g_submenu_bg_size = 0;
     if (!g_submenu_was_paused && g_paused) player_pause_toggle();
+}
+
+static void submenu_switch_tab(int tab)
+{
+    if (tab == g_submenu_tab) return;
+    g_submenu_tab = tab;
 }
 
 static void draw_submenu(FBDev *fb)
 {
-    int n_opts = g_info_item.sub_count + 1;   /* JF_MAX_SUBS+1 = 9 max */
+    /* Start from the captured backdrop every time — see g_submenu_bg. */
+    submenu_bg_restore(fb);
 
-    int box_w = 280;
-    /* Must exactly match every increment below (header, n_opts rows, sync
-     * line, gap, 3 hint lines, padding) — computed directly from those same
-     * numbers instead of separately, so it can't drift out of sync with the
-     * actual content again like it did before (text drawn past the box's
-     * own bottom edge). */
-    int box_h = 10 + 15 + n_opts * 15 + 15 + 8 + 3 * 12 + 8;
+    int is_audio = (g_submenu_tab == SUBMENU_TAB_AUDIO);
+    int n_opts   = submenu_option_count();
+    int sel      = is_audio ? g_submenu_audio_sel : g_submenu_sub_sel;
+
+    /* At least one row of vertical space even when a tab has no tracks, so
+     * the "none" message below has somewhere to go. */
+    int n_rows   = n_opts > 0 ? n_opts : 1;
+    /* The sync readout is subtitle-only — it adjusts subtitle timing, and
+     * there's no audio equivalent worth the row. */
+    int extra_rows = is_audio ? 0 : 1;
+
+    /* Wide enough for a full server-composed audio DisplayTitle — "English -
+     * Dolby Digital 5.1 - Default" is 37 characters, and at 8px per glyph
+     * plus the box's own margins that needs ~340. Anything narrower truncates
+     * exactly the suffix that distinguishes a commentary track from the main
+     * mix, which is the whole reason for showing DisplayTitle rather than a
+     * bare language. Still leaves a comfortable margin at 640 wide. */
+    int box_w = 360;
+
+    /* Everything in the box that isn't a track row: tab header, optional sync
+     * line, gap, 3 hint lines, padding. Kept as one expression so the height
+     * below can't drift out of sync with what's actually drawn — which it did
+     * once before, spilling text past the box's own bottom edge. */
+    int chrome_h = 10 + 15 + extra_rows * 15 + 8 + 3 * 12 + 8;
+
+    /* The full list doesn't always fit. Eight subtitle tracks plus "Off" is
+     * JF_MAX_SUBS's worst case, and at NTSC's 240 lines that box overflows
+     * the overscan-safe area at both ends — on a real CRT the first and last
+     * rows would simply be off the tube. Cap the rows to what fits inside the
+     * safe area and scroll the list instead, so no row is ever undisplayable. */
+    int avail_h  = fb->height - 2 * SAFE_Y;
+    int max_rows = (avail_h - chrome_h) / 15;
+    if (max_rows < 1) max_rows = 1;
+    int shown = n_rows < max_rows ? n_rows : max_rows;
+
+    /* Scroll offset per tab, nudged just far enough to keep the selection on
+     * screen — same minimal-movement behaviour as the browse list, rather
+     * than re-centring on every keypress. */
+    static int submenu_scroll[2] = { 0, 0 };
+    int *scroll = &submenu_scroll[g_submenu_tab];
+    if (sel < *scroll)          *scroll = sel;
+    if (sel >= *scroll + shown) *scroll = sel - shown + 1;
+    if (*scroll > n_opts - shown) *scroll = n_opts - shown;
+    if (*scroll < 0)              *scroll = 0;
+
+    int box_h = chrome_h + shown * 15;
     int box_x = (fb->width - box_w) / 2, box_y = fb->height / 2 - box_h / 2;
     fb_fill_rect_alpha(fb, box_x, box_y, box_w, box_h, 0, 0, 0, 225);
 
     int list_x = box_x + 12, list_y = box_y + 10;
     int label_max_w = box_w - 24;   /* box_w minus left/right margin, for truncation below */
-    draw_text(fb, list_x, list_y, "SUBTITLES", 1, COL_HINT);
-    list_y += 15;
 
-    for (int i = 0; i < n_opts; i++) {
-        int is_off  = (i == 0);
-        int active  = is_off ? (g_current_sub_index < 0) : (g_current_sub_index == i - 1);
-        const char *label = is_off ? "Off" : g_info_item.subs[i - 1].label;
-        if (!label || !label[0]) label = "Unknown";
+    /* Tab header — the inactive tab stays visible (dimmed) rather than being
+     * hidden, so there's something on screen telling you the other one is
+     * there and that L/R reaches it. */
+    {
+        const char *audio_label = "AUDIO";
+        const char *subs_label  = "SUBTITLES";
+        int gap = 3 * 8;
+        int audio_x = list_x;
+        int subs_x  = audio_x + text_width(fb, audio_label, 1) + gap;
+        if (is_audio) {
+            draw_text(fb, audio_x, list_y, audio_label, 1, COL_TITLE);
+            draw_text(fb, subs_x,  list_y, subs_label,  1, COL_HINT);
+        } else {
+            draw_text(fb, audio_x, list_y, audio_label, 1, COL_HINT);
+            draw_text(fb, subs_x,  list_y, subs_label,  1, COL_TITLE);
+        }
+        /* Only when some of the list is off-screen — otherwise it's noise. */
+        if (shown < n_opts) {
+            char pos[16];
+            snprintf(pos, sizeof(pos), "%d/%d", sel + 1, n_opts);
+            draw_text(fb, box_x + box_w - 12 - text_width(fb, pos, 1),
+                      list_y, pos, 1, COL_HINT);
+        }
+        list_y += 15;
+    }
 
-        if (i == g_submenu_sel)
+    if (n_opts == 0) {
+        draw_text(fb, list_x, list_y, "  (no tracks)", 1, COL_HINT);
+        list_y += 15;
+    }
+
+    for (int i = *scroll; i < n_opts && i < *scroll + shown; i++) {
+        const char *label;
+        int active;
+
+        if (is_audio) {
+            const JfAudioTrack *a = &g_info_item.audio[i];
+            label  = a->label[0] ? a->label : "Unknown";
+            active = (g_current_audio_index == a->index);
+        } else {
+            int is_off = (i == 0);
+            label  = is_off ? "Off" : g_info_item.subs[i - 1].label;
+            active = is_off ? (g_current_sub_index < 0)
+                            : (g_current_sub_index == g_info_item.subs[i - 1].index);
+            if (!label || !label[0]) label = "Unknown";
+        }
+
+        if (i == sel)
             fb_fill_rect_alpha(fb, box_x + 4, list_y - 2, box_w - 8, 14, COL_SEL_BG, 220);
 
-        char line[56];
+        char line[80];
         snprintf(line, sizeof(line), "%s%s", active ? "> " : "  ", label);
-        /* A long DisplayTitle from the server (seen in practice: things
-         * like "Undefined - SUBRIP - External") drawn past the box's own
-         * width made the text stick out past the dark background behind
-         * it — clip it to fit instead. */
+        /* A long DisplayTitle from the server (seen in practice: things like
+         * "Undefined - SUBRIP - External", or "English - Dolby Digital 5.1 -
+         * Default" for audio) drawn past the box's own width made the text
+         * stick out past the dark background behind it — clip it to fit. */
         truncate_to_width(fb, line, 1, label_max_w);
         if (active) draw_text(fb, list_x, list_y, line, 1, COL_RESUME);
         else        draw_text(fb, list_x, list_y, line, 1, COL_ITEM);
         list_y += 15;
     }
 
-    char syncline[32];
-    snprintf(syncline, sizeof(syncline), "Sync: %+.1fs", g_sub_delay_extra);
-    draw_text(fb, list_x, list_y, syncline, 1, COL_ITEM);
-    list_y += 15 + 8;   /* + gap before the hint block */
+    if (!is_audio) {
+        char syncline[32];
+        snprintf(syncline, sizeof(syncline), "Sync: %+.1fs", g_sub_delay_extra);
+        draw_text(fb, list_x, list_y, syncline, 1, COL_ITEM);
+        list_y += 15;
+    }
+    list_y += 8;   /* gap before the hint block */
 
-    const char *hint1 = "UP/DOWN: select subtitle";
-    const char *hint2 = "LEFT/RIGHT: adjust subtitle offset";
+    const char *hint1 = is_audio ? "UP/DOWN: select audio track"
+                                  : "UP/DOWN: select subtitle";
+    const char *hint2 = is_audio ? "L/R: switch tab"
+                                  : "L/R: switch tab   LEFT/RIGHT: sync";
     const char *hint3 = "B: apply    A: cancel";
     draw_text(fb, box_x + (box_w - text_width(fb, hint1, 1)) / 2, list_y, hint1, 1, COL_HINT);
     list_y += 12;
@@ -2878,10 +3750,35 @@ static void draw_submenu(FBDev *fb)
 
 static void submenu_confirm(FBDev *fb)
 {
-    int new_index = g_submenu_sel == 0 ? -1 : g_info_item.subs[g_submenu_sel - 1].index;
+    int new_sub = (g_submenu_sub_sel == 0 || g_info_item.sub_count == 0)
+                    ? -1 : g_info_item.subs[g_submenu_sub_sel - 1].index;
+    int new_audio = (g_info_item.audio_count > 0)
+                    ? g_info_item.audio[g_submenu_audio_sel].index
+                    : g_current_audio_index;
+
     submenu_close();
-    if (new_index == g_current_sub_index) return;   /* no actual change */
-    subtitle_apply(fb, new_index);
+
+    /* An audio change can only be applied by rebuilding the stream URL, so it
+     * subsumes any subtitle change made in the same visit — both get baked
+     * into the one restart rather than restarting twice. */
+    if (new_audio != g_current_audio_index) {
+        double pos = play_position();
+        g_current_audio_index = new_audio;
+
+        int new_burn_in = -1;
+        if (new_sub >= 0) {
+            const JfSubtitle *s = find_sub(new_sub);
+            if (s && !jf_subtitle_is_text(s->codec)) new_burn_in = new_sub;
+        }
+        g_burned_in_sub_index = new_burn_in;
+        g_current_sub_index   = new_sub;
+
+        player_stop();
+        play(fb, g_info_item.id, pos);   /* re-loads a client-side subtitle itself */
+        return;
+    }
+
+    if (new_sub != g_current_sub_index) subtitle_apply(fb, new_sub);
 }
 
 /* play_position() plus whatever seek is currently accumulating but hasn't
@@ -2965,9 +3862,9 @@ static void play(FBDev *fb, const char *item_id, double offset_secs)
     int64_t start_ticks = (int64_t)(offset_secs * 10000000.0);
     jf_make_play_session_id(g_play_session_id, sizeof(g_play_session_id));
 
-    char url[600];
+    char url[700];
     jf_stream_url(&g_cfg, item_id, &g_stream_profile, start_ticks, g_play_session_id,
-                  g_burned_in_sub_index, url, sizeof(url));
+                  g_burned_in_sub_index, g_current_audio_index, url, sizeof(url));
 
     char delay_arg[16];
     snprintf(delay_arg, sizeof(delay_arg), "%.2f", AUDIO_DELAY_SEC);
@@ -3151,7 +4048,7 @@ static void play_audio(FBDev *fb, int queue_pos)
     unlink(AF_EXPORT_PATH);   /* don't let the visualizer read a stale previous track's data */
 
     jf_make_play_session_id(g_play_session_id, sizeof(g_play_session_id));
-    char url[600];
+    char url[700];
     jf_audio_stream_url(&g_cfg, it->id, g_play_session_id, url, sizeof(url));
 
     g_play_offset     = 0.0;
@@ -3447,6 +4344,57 @@ static int run_preview_browse(int sel, int list_mode)
     return 0;
 }
 
+/* Dev tool for the track picker's layout. The picker only ever appears over
+ * live playback, which needs a real framebuffer for mplayer to write into and
+ * so can't be reached off-hardware at all — without this there is no way to
+ * look at it short of deploying to a MiSTer and starting a film. Fetches one
+ * real item's streams from the server, draws the menu over a blank frame, and
+ * dumps it for tools/raw_to_png.py.
+ *
+ * Honours MISTERFIN_FB for geometry (see fb.c), so the same item can be
+ * checked at PAL's 288 lines and NTSC's 240 — the box is sized from its
+ * content and the shorter frame is where it would overflow first. */
+static int run_preview_submenu(const char *item_id, int tab)
+{
+    FBDev fb;
+    if (fb_open(&fb, "/dev/fb0") < 0) { fprintf(stderr, "no framebuffer\n"); return 1; }
+    SAFE_Y = (int)(SAFE_X / par_correction(&fb) + 0.5);
+
+    if (!jf_config_load(&g_cfg))          { fprintf(stderr, "jellyfin.conf not found\n"); return 1; }
+    if (jf_resolve_user_id(&g_cfg) != 1)  { fprintf(stderr, "user resolve failed\n"); return 1; }
+    if (!jf_get_item_details(&g_cfg, item_id, &g_info_item)) {
+        fprintf(stderr, "could not fetch item %s\n", item_id);
+        return 1;
+    }
+
+    fprintf(stderr, "%s: %d audio track(s), %d subtitle track(s)\n",
+            g_info_item.name, g_info_item.audio_count, g_info_item.sub_count);
+
+    g_current_audio_index = default_audio_index();
+    g_current_sub_index   = g_info_item.sub_count > 0 ? g_info_item.subs[0].index : -1;
+    g_submenu_visible     = 1;
+    g_submenu_audio_sel   = 0;
+    g_submenu_sub_sel     = 0;
+
+    fb_clear(&fb);
+    memcpy(fb.mem, fb.back, (size_t)fb.stride * fb.height);
+    submenu_bg_capture(&fb);
+
+    /* Draw the OTHER tab first and only then the requested one, so what gets
+     * dumped is a frame that has been switched to rather than opened on. The
+     * two tabs are different sizes, so this is the path where the taller
+     * box's leftovers used to survive around the shorter one — rendering a
+     * single tab in isolation would never show it. */
+    g_submenu_tab = (tab == SUBMENU_TAB_AUDIO) ? SUBMENU_TAB_SUBS : SUBMENU_TAB_AUDIO;
+    draw_submenu(&fb);
+    g_submenu_tab = tab;
+    draw_submenu(&fb);
+
+    printf("%d %d %d\n", fb.width, fb.height, fb.stride);
+    fb_close(&fb);
+    return 0;
+}
+
 /* Restores whatever screen was behind the About overlay once it closes —
  * previously this only handled STATE_BROWSE, so closing About from the info
  * screen or the now-playing screen left the last About frame frozen on
@@ -3473,20 +4421,75 @@ static void redraw_current_screen(FBDev *fb, AppState state)
  * the screen just goes black-to-browse same as before — no flash. */
 #define STARTUP_PENDING -2
 #define STARTUP_CONFIG_MISSING -3
+#define STARTUP_NEED_QUICK_CONNECT -4
 static pthread_mutex_t g_startup_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int g_startup_result = STARTUP_PENDING;
+
+/* Loads the library listing once a credential is known good. Shared by the
+ * normal startup path and by the Quick Connect one, which reaches this point
+ * minutes later and from a different thread. */
+static void startup_enter_browse(void)
+{
+    push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL);
+}
+
+/* Kicks off the background cover-grid prefetch. Deliberately not started
+ * unconditionally at launch: it needs a resolved user and a working
+ * credential, and starting it from the setup or Quick Connect screens meant
+ * firing a /UserViews with an empty userId and no token — harmless against a
+ * permissive server, a guaranteed 401 against a real one, and a confusing
+ * entry in the log for anyone debugging why their client won't connect.
+ * Called from both paths that reach a signed-in library. */
+static void start_grid_prefetch(void)
+{
+    pthread_t tid;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_create(&tid, &attr, grid_prefetch_thread, NULL);
+    pthread_attr_destroy(&attr);
+}
 
 static void *startup_resolve_thread(void *arg)
 {
     (void)arg;
     int result;
+
     if (!jf_config_load(&g_cfg)) {
-        result = STARTUP_CONFIG_MISSING;
-    } else {
-        result = jf_resolve_user_id(&g_cfg);
-        if (result == 1)
-            push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL);
+        pthread_mutex_lock(&g_startup_mutex);
+        g_startup_result = STARTUP_CONFIG_MISSING;
+        pthread_mutex_unlock(&g_startup_mutex);
+        return NULL;
     }
+
+    /* Before any request: this goes in every Authorization header, and must
+     * be identical between authenticating and using the resulting token. */
+    jf_device_id_init(&g_cfg);
+
+    if (jf_token_load(&g_cfg) && jf_credential_works(&g_cfg)) {
+        /* A previously earned Quick Connect token, still accepted. Checked
+         * before the config's API key so that re-authenticating once sticks
+         * even if a stale key is left in the file. */
+        result = 1;
+        startup_enter_browse();
+    } else if (g_cfg.api_key[0] && g_cfg.username[0]) {
+        /* Classic path: an admin-issued API key plus a username to resolve.
+         * jf_token_load may have overwritten the credential with a dead
+         * token, so put the key back first. */
+        strncpy(g_cfg.token, g_cfg.api_key, sizeof(g_cfg.token) - 1);
+        g_cfg.user_id[0] = '\0';
+        result = jf_resolve_user_id(&g_cfg);
+        if (result == 1) startup_enter_browse();
+    } else {
+        /* No usable credential — a saved token that no longer works ends up
+         * here too, which is what makes a revoked or expired login recover by
+         * itself instead of showing an error nobody can act on. */
+        jf_token_clear();
+        g_cfg.token[0] = '\0';
+        g_cfg.user_id[0] = '\0';
+        result = STARTUP_NEED_QUICK_CONNECT;
+    }
+
     pthread_mutex_lock(&g_startup_mutex);
     g_startup_result = result;
     pthread_mutex_unlock(&g_startup_mutex);
@@ -3500,6 +4503,10 @@ int main(int argc, char **argv)
     if (argc > 1 && strcmp(argv[1], "--preview-browse") == 0)
         return run_preview_browse(argc > 2 ? atoi(argv[2]) : -1,
                                    argc > 3 && strcmp(argv[3], "list") == 0);
+    if (argc > 1 && strcmp(argv[1], "--preview-submenu") == 0)
+        return run_preview_submenu(argc > 2 ? argv[2] : "",
+                                    (argc > 3 && strcmp(argv[3], "audio") == 0)
+                                        ? SUBMENU_TAB_AUDIO : SUBMENU_TAB_SUBS);
 
     srand((unsigned)time(NULL));   /* for the About screen's starfield */
 
@@ -3515,6 +4522,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "Cannot open /dev/fb0\n");
         return 1;
     }
+    g_headless = fb.headless;   /* see g_headless' own comment */
     /* SAFE_Y as a plain pixel count made the top/bottom margin look
      * noticeably BIGGER than the left/right margin on real hardware, even
      * though 20 < 24 — because our pixels aren't square. Physically,
@@ -3551,11 +4559,19 @@ int main(int argc, char **argv)
     pthread_join(startup_tid, NULL);
 
     AppState state;
+    pthread_t qc_tid;
+    int qc_running = 0;
     int resolved = g_startup_result;
     if (resolved == STARTUP_CONFIG_MISSING) {
         state = STATE_CONFIG_ERROR;
         snprintf(g_setup_reason, sizeof(g_setup_reason), "jellyfin.conf not found or incomplete");
         draw_setup_screen(&fb, g_setup_reason);
+    } else if (resolved == STARTUP_NEED_QUICK_CONNECT) {
+        state = STATE_QUICK_CONNECT;
+        qc_set_state(QC_STARTING);
+        pthread_create(&qc_tid, NULL, quick_connect_thread, NULL);
+        qc_running = 1;
+        draw_quick_connect(&fb);
     } else if (resolved == 1) {
         state = STATE_BROWSE;
     } else {
@@ -3595,15 +4611,15 @@ int main(int argc, char **argv)
     /* Silently pre-fetch every library's grid background in the
      * background, so switching to one the user hasn't visited yet this
      * session doesn't show a blank/dim background while it fetches — see
-     * grid_prefetch_thread's own comment. */
-    {
-        pthread_t grid_tid;
-        pthread_attr_t grid_attr;
-        pthread_attr_init(&grid_attr);
-        pthread_attr_setdetachstate(&grid_attr, PTHREAD_CREATE_DETACHED);
-        pthread_create(&grid_tid, &grid_attr, grid_prefetch_thread, NULL);
-        pthread_attr_destroy(&grid_attr);
-    }
+     * grid_prefetch_thread's own comment.
+     *
+     * Only once there's actually a session to fetch with. It used to start
+     * unconditionally, which meant the setup and Quick Connect screens each
+     * fired a /UserViews with an empty userId and no credential — harmless
+     * against a permissive server, but a guaranteed 401 against a real one,
+     * and a confusing entry in the server log for anyone debugging why their
+     * client won't connect. */
+    if (state == STATE_BROWSE) start_grid_prefetch();
 
     int playing = 0;
     int spinner_frame_ctr = 0;
@@ -3614,6 +4630,10 @@ int main(int argc, char **argv)
     double last_input_rescan = 0.0;
     while (g_running) {
         int inp = input_poll();
+        /* Must be called every tick (it drives the repeat timers), but only
+         * OR'd in by the screens that want held-to-scroll — see
+         * input_repeat()'s own comment for why it isn't just part of inp. */
+        int nav_repeat = input_repeat();
         double loop_now = now_sec();
 
         /* Re-scan /dev/input every few seconds — a wireless pad that idles
@@ -3652,19 +4672,31 @@ int main(int argc, char **argv)
 
         if (g_submenu_visible) {
             static double last_nav_press = 0.0;
-            int n_opts = g_info_item.sub_count + 1;
-            if ((inp & (INP_UP | INP_DOWN | INP_LEFT | INP_RIGHT)) &&
+            int n_opts   = submenu_option_count();
+            int is_audio = (g_submenu_tab == SUBMENU_TAB_AUDIO);
+            int *sel     = is_audio ? &g_submenu_audio_sel : &g_submenu_sub_sel;
+
+            /* Shoulder buttons switch tabs, leaving LEFT/RIGHT free for
+             * subtitle sync (which needs to stay a fine repeated nudge, and
+             * has no audio equivalent to share the keys with). */
+            if (inp & INP_L) submenu_switch_tab(SUBMENU_TAB_AUDIO);
+            if (inp & INP_R) submenu_switch_tab(SUBMENU_TAB_SUBS);
+
+            int menu_inp = inp | nav_repeat;   /* held UP/DOWN walks the list, held LEFT/RIGHT keeps nudging sync */
+            if ((menu_inp & (INP_UP | INP_DOWN | INP_LEFT | INP_RIGHT)) &&
                 loop_now - last_nav_press > 0.15) {
                 last_nav_press = loop_now;
-                if (inp & INP_UP)    { if (g_submenu_sel > 0) g_submenu_sel--; }
-                if (inp & INP_DOWN)  { if (g_submenu_sel < n_opts - 1) g_submenu_sel++; }
+                if (menu_inp & INP_UP)    { if (*sel > 0) (*sel)--; }
+                if (menu_inp & INP_DOWN)  { if (*sel < n_opts - 1) (*sel)++; }
                 /* Live-tunable on top of the fixed baseline (AUDIO_DELAY_SEC
                  * + SUBTITLE_SYNC_FUDGE_SEC + g_play_offset) — for whatever
                  * that fixed default doesn't cover on a specific subtitle
                  * file. Applies immediately if a subtitle is already
-                 * loaded. */
-                if (inp & INP_LEFT)  { g_sub_delay_extra -= 0.1; sub_delay_send(); }
-                if (inp & INP_RIGHT) { g_sub_delay_extra += 0.1; sub_delay_send(); }
+                 * loaded. Subtitle tab only: there's nothing for it to mean
+                 * on the audio tab, and silently changing subtitle timing
+                 * from a screen not showing it would be a surprise. */
+                if (!is_audio && (menu_inp & INP_LEFT))  { g_sub_delay_extra -= 0.1; sub_delay_send(); }
+                if (!is_audio && (menu_inp & INP_RIGHT)) { g_sub_delay_extra += 0.1; sub_delay_send(); }
             }
             if (inp & INP_A) { submenu_confirm(&fb); input_drain(); continue; }
             /* SELECT also closes — a SELECT press while already open was a
@@ -3698,10 +4730,49 @@ int main(int argc, char **argv)
             draw_setup_screen(&fb, g_setup_reason);   /* redrawn every frame for the starfield */
             break;
 
+        case STATE_QUICK_CONNECT: {
+            QcState qc = qc_get_state(NULL, 0);
+
+            if (qc == QC_AUTHENTICATED) {
+                /* The handshake thread has the token; loading the library is
+                 * a few blocking round-trips, so do it here on the main
+                 * thread with the "Signed in" frame already on screen. */
+                pthread_join(qc_tid, NULL);
+                qc_running = 0;
+                startup_enter_browse();
+                state = STATE_BROWSE;
+                start_grid_prefetch();   /* skipped at launch — see its comment */
+                draw_browse(&fb);
+                input_drain();
+                break;
+            }
+
+            /* B retries a dead request rather than making the user relaunch —
+             * a code expiring while you walk to another room is the normal
+             * way this fails, not an exceptional one. */
+            if ((inp & INP_B) && (qc == QC_FAILED || qc == QC_UNAVAILABLE)) {
+                if (qc_running) { pthread_join(qc_tid, NULL); qc_running = 0; }
+                qc_set_state(QC_STARTING);
+                pthread_create(&qc_tid, NULL, quick_connect_thread, NULL);
+                qc_running = 1;
+                input_drain();
+                break;
+            }
+            if (inp & INP_A) { g_running = 0; break; }
+
+            draw_quick_connect(&fb);   /* every frame, for the starfield */
+            break;
+        }
+
         case STATE_BROWSE: {
             int nav = 0;
             int at_root      = (g_stack[g_stack_depth - 1].kind == FRAME_VIEWS);
             int is_carousel  = at_root && !g_root_list_mode;
+            /* Browsing is exactly the case auto-repeat exists for. Safe to
+             * fold straight into inp: input_repeat() only ever returns
+             * direction bits, so the A/B/SELECT handling further down still
+             * sees nothing but real press edges. */
+            inp |= nav_repeat;
 
             if (g_confirm_exit) {
                 /* Dialog eats all other input while open. */
@@ -3761,16 +4832,17 @@ int main(int argc, char **argv)
                     nav = 1;
                 }
             } else {
-                if (inp & INP_UP && g_item_count > 0) {
-                    if (g_sel > 0) g_sel--;
-                    if (g_sel < g_scroll) g_scroll = g_sel;
-                    nav = 1;
-                }
-                if (inp & INP_DOWN && g_item_count > 0) {
-                    if (g_sel < g_item_count - 1) g_sel++;
-                    if (g_sel >= g_scroll + visible_rows(&fb)) g_scroll = g_sel - visible_rows(&fb) + 1;
-                    nav = 1;
-                }
+                /* LEFT/RIGHT have nothing else to do in a plain list, so
+                 * they're the whole-page jump — the fast way through a long
+                 * library. The shoulder buttons do the same thing for pads
+                 * where reaching a D-pad direction and a face button at once
+                 * is awkward, and because PageUp/PageDown is what a keyboard
+                 * user will reach for. */
+                int page = visible_rows(&fb);
+                if (inp & INP_UP)                   nav |= browse_move_sel(&fb, -1);
+                if (inp & INP_DOWN)                 nav |= browse_move_sel(&fb, +1);
+                if (inp & (INP_LEFT  | INP_L))      nav |= browse_move_sel(&fb, -page);
+                if (inp & (INP_RIGHT | INP_R))      nav |= browse_move_sel(&fb, +page);
             }
             if (at_root) g_root_sel = g_sel;   /* see g_root_sel's own comment */
             if (inp & INP_A && g_item_count > 0) {
@@ -3779,7 +4851,14 @@ int main(int argc, char **argv)
                 switch (it->type) {
                 case JF_TYPE_FOLDER:
                 case JF_TYPE_ARTIST:
-                    push_frame(FRAME_ITEMS, it->name, it->id, NULL, NULL);
+                    /* The two home rows look like folders but have no parent
+                     * to list — they're their own kind of frame. */
+                    if (view_is_resume(it))
+                        push_frame(FRAME_RESUME, "Continue Watching", NULL, NULL, NULL);
+                    else if (view_is_nextup(it))
+                        push_frame(FRAME_NEXTUP, "Next Up", NULL, NULL, NULL);
+                    else
+                        push_frame(FRAME_ITEMS, it->name, it->id, NULL, NULL);
                     nav = 1;
                     break;
                 case JF_TYPE_ALBUM: {
@@ -3850,6 +4929,10 @@ int main(int argc, char **argv)
                 state = STATE_PLAYING;
                 g_current_sub_index = -1;
                 g_burned_in_sub_index = -1;
+                /* Start on whatever the source marks as default, so the track
+                 * picker can show a meaningful "current" row before any
+                 * choice has been made. */
+                g_current_audio_index = default_audio_index();
                 play(&fb, g_info_item.id, offset);
                 input_drain();
             } else if ((inp & INP_SELECT) && g_info_item.resume_ticks > 0 && !g_info_item.played) {
@@ -3858,6 +4941,7 @@ int main(int argc, char **argv)
                 state = STATE_PLAYING;
                 g_current_sub_index = -1;
                 g_burned_in_sub_index = -1;
+                g_current_audio_index = default_audio_index();
                 play(&fb, g_info_item.id, 0.0);
                 input_drain();
             }
@@ -4045,8 +5129,15 @@ int main(int argc, char **argv)
     info_assets_free();
     ddr_close();
     cursor_show();
-    fb_clear(&fb);
-    fb_flip(&fb);
+    /* Blanking on the way out leaves the MiSTer showing an empty screen
+     * rather than a frozen UI. Headless there's no screen to leave in any
+     * state — and doing it anyway would overwrite the final MISTERFIN_FRAME_OUT
+     * dump with an all-black frame, i.e. destroy the screenshot the run was
+     * for. */
+    if (!fb.headless) {
+        fb_clear(&fb);
+        fb_flip(&fb);
+    }
     fb_close(&fb);
     input_close();
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <sys/wait.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <linux/input.h>
@@ -29,6 +30,7 @@
 #include "stb_image.h"
 #include "ddr.h"
 #include "jellyfin.h"
+#include "json.h"
 #include "subtitles.h"
 
 #define MPLAYER      "/media/fat/misterfin/mplayer-arm"
@@ -139,31 +141,93 @@ static pthread_mutex_t g_upd_mutex = PTHREAD_MUTEX_INITIALIZER;
  * APP_VERSION. No-op-safe if that repo doesn't exist yet (this project is
  * local-only for now) — the request just fails and the About screen shows
  * no update line, same as any other network hiccup. */
+/* Runs a command with an explicit argv and NO SHELL, optionally capturing
+ * stdout. Same reasoning as jf_curl_run in jellyfin.c: the update path
+ * interpolates a GitHub-supplied release tag, and with a shell that tag is
+ * parsed by /bin/sh. Returns 1 if the command exited 0. */
+static int run_no_shell(char *const argv[], char *out, int outlen)
+{
+    if (out && outlen > 0) out[0] = '\0';
+
+    int pfd[2];
+    if (out && pipe(pfd) != 0) return 0;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        if (out) { close(pfd[0]); close(pfd[1]); }
+        return 0;
+    }
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (out) { dup2(pfd[1], STDOUT_FILENO); close(pfd[0]); close(pfd[1]); }
+        else if (devnull >= 0) dup2(devnull, STDOUT_FILENO);
+        if (devnull >= 0) { dup2(devnull, STDERR_FILENO); close(devnull); }
+        execvp(argv[0], argv);
+        _exit(127);
+    }
+
+    if (out) {
+        close(pfd[1]);
+        int len = 0;
+        for (;;) {
+            ssize_t got = read(pfd[0], out + len, (size_t)(outlen - 1 - len));
+            if (got <= 0) break;
+            len += (int)got;
+            if (len >= outlen - 1) break;
+        }
+        out[len] = '\0';
+        close(pfd[0]);
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+/* A release tag is pasted into a download URL and a filename, so it gets a
+ * strict allowlist rather than being trusted. Real tags look like "v0.9.3".
+ * Returns 1 if the tag is safe to use. */
+static int update_tag_is_sane(const char *tag)
+{
+    if (!tag || !tag[0] || strlen(tag) > 24) return 0;
+    for (const char *p = tag; *p; p++) {
+        int ok = (*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+                 (*p >= '0' && *p <= '9') || *p == '.' || *p == '-' || *p == '_';
+        if (!ok) return 0;
+    }
+    return 1;
+}
+
+/* Deliberately WITHOUT -k, unlike requests to the user's own Jellyfin server.
+ * A self-signed certificate is normal for a home media server, so verification
+ * is relaxed there; github.com has a valid certificate and there is no reason
+ * to accept anything else. It matters more here than anywhere else in the app:
+ * this path decides which binary gets written over misterfin-arm and run at
+ * next launch, so accepting a substituted response is accepting a substituted
+ * executable. No amount of quoting downstream fixes that. */
 static void *update_check_thread(void *arg)
 {
     (void)arg;
-    FILE *f = popen(
-        "curl -sfk --max-time 8 "
-        "https://api.github.com/repos/puddingstudio/MiSTerFin/releases/latest "
-        "2>/dev/null", "r");
-    if (!f) {
-        pthread_mutex_lock(&g_upd_mutex);
-        g_upd_state = UPD_FAILED;
-        pthread_mutex_unlock(&g_upd_mutex);
-        return NULL;
-    }
-    char buf[4096] = {0};
-    fread(buf, 1, sizeof(buf) - 1, f);
-    pclose(f);
 
-    char *p = strstr(buf, "\"tag_name\"");
-    if (!p) goto fail;
-    p = strchr(p, ':'); if (!p) goto fail;
-    p++;
-    while (*p == ' ' || *p == '"') p++;
+    char *const argv[] = {
+        (char *)"curl", (char *)"-fsSL", (char *)"--proto", (char *)"=https",
+        (char *)"--tlsv1.2", (char *)"--max-time", (char *)"8",
+        (char *)"https://api.github.com/repos/puddingstudio/MiSTerFin/releases/latest",
+        NULL
+    };
+
+    char buf[8192];
+    if (!run_no_shell(argv, buf, sizeof(buf))) goto fail;
+
+    /* Parsed properly rather than scanned for — the same reason every other
+     * response in this app is. */
+    JsonDoc doc;
+    if (!json_parse(&doc, buf)) goto fail;
     char tag[32] = {0};
-    int i = 0;
-    while (*p && *p != '"' && i < 31) tag[i++] = *p++;
+    json_copy_str(&doc, NULL, "tag_name", tag, sizeof(tag));
+    json_free(&doc);
+
+    if (!update_tag_is_sane(tag)) goto fail;
 
     pthread_mutex_lock(&g_upd_mutex);
     strncpy(g_upd_latest, tag, sizeof(g_upd_latest) - 1);
@@ -177,8 +241,6 @@ fail:
     pthread_mutex_unlock(&g_upd_mutex);
     return NULL;
 }
-
-/* ── Install ──────────────────────────────────────────────────────────────── */
 
 typedef enum { INST_IDLE, INST_DOWNLOADING, INST_DONE, INST_FAILED } InstallState;
 
@@ -206,22 +268,55 @@ static void *install_thread(void *arg)
     tag[sizeof(tag) - 1] = '\0';
     pthread_mutex_unlock(&g_upd_mutex);
 
-    char cmd[512];
-    snprintf(cmd, sizeof(cmd),
-        "curl -Lsk --max-time 120 "
-        "https://github.com/puddingstudio/MiSTerFin/releases/download/%s/misterfin-%s.zip "
-        "-o /tmp/misterfin-update.zip 2>/dev/null",
-        tag, tag);
-    if (system(cmd) != 0) { set_inst(INST_FAILED); return NULL; }
+    /* Re-checked here, not just where it was parsed: the tag crosses a mutex
+     * and a thread boundary in between, and this is the point where it turns
+     * into a URL. */
+    if (!update_tag_is_sane(tag)) { set_inst(INST_FAILED); return NULL; }
 
-    system("rm -rf /tmp/misterfin-update/");
-    if (system("unzip -q -o /tmp/misterfin-update.zip -d /tmp/misterfin-update/ 2>/dev/null") != 0)
-        { set_inst(INST_FAILED); return NULL; }
+    char url[256];
+    snprintf(url, sizeof(url),
+             "https://github.com/puddingstudio/MiSTerFin/releases/download/%s/misterfin-%s.zip",
+             tag, tag);
 
-    system("cp -r /tmp/misterfin-update/misterfin/font/.    /media/fat/misterfin/font/    2>/dev/null");
-    system("cp -r /tmp/misterfin-update/misterfin/subfont/. /media/fat/misterfin/subfont/ 2>/dev/null");
-    system("cp -r /tmp/misterfin-update/misterfin/toasty/.  /media/fat/misterfin/toasty/  2>/dev/null");
-    system("cp    /tmp/misterfin-update/misterfin/about.png /media/fat/misterfin/about.png 2>/dev/null");
+    {
+        char *const argv[] = {
+            (char *)"curl", (char *)"-fsSL", (char *)"--proto", (char *)"=https",
+            (char *)"--tlsv1.2", (char *)"--max-time", (char *)"120",
+            url, (char *)"-o", (char *)"/tmp/misterfin-update.zip", NULL
+        };
+        if (!run_no_shell(argv, NULL, 0)) { set_inst(INST_FAILED); return NULL; }
+    }
+
+    {
+        char *const argv[] = { (char *)"rm", (char *)"-rf",
+                               (char *)"/tmp/misterfin-update/", NULL };
+        run_no_shell(argv, NULL, 0);
+    }
+    {
+        /* -qq quiet, -o overwrite. Info-ZIP refuses absolute and ../ paths by
+         * default, so a crafted archive can't escape the destination. */
+        char *const argv[] = { (char *)"unzip", (char *)"-qq", (char *)"-o",
+                               (char *)"/tmp/misterfin-update.zip",
+                               (char *)"-d", (char *)"/tmp/misterfin-update/", NULL };
+        if (!run_no_shell(argv, NULL, 0)) { set_inst(INST_FAILED); return NULL; }
+    }
+
+    static const char *const asset_copies[][3] = {
+        { "-r", "/tmp/misterfin-update/misterfin/font/.",    "/media/fat/misterfin/font/"    },
+        { "-r", "/tmp/misterfin-update/misterfin/subfont/.", "/media/fat/misterfin/subfont/" },
+        { "-r", "/tmp/misterfin-update/misterfin/toasty/.",  "/media/fat/misterfin/toasty/"  },
+        { NULL, "/tmp/misterfin-update/misterfin/about.png", "/media/fat/misterfin/about.png" },
+    };
+    for (size_t i = 0; i < sizeof(asset_copies) / sizeof(asset_copies[0]); i++) {
+        char *argv[6];
+        int n = 0;
+        argv[n++] = (char *)"cp";
+        if (asset_copies[i][0]) argv[n++] = (char *)asset_copies[i][0];
+        argv[n++] = (char *)asset_copies[i][1];
+        argv[n++] = (char *)asset_copies[i][2];
+        argv[n]   = NULL;
+        run_no_shell(argv, NULL, 0);
+    }
 
     FILE *f = fopen("/tmp/misterfin_apply_update.sh", "w");
     if (f) {

--- a/src/subtitles.c
+++ b/src/subtitles.c
@@ -1,0 +1,165 @@
+#include "subtitles.h"
+#include "jellyfin.h"   /* jf_text_to_display */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* Returns the length of a recognised inline markup tag at p, or 0.
+ *
+ * Deliberately an allowlist rather than "skip from '<' to '>'": subtitle
+ * dialogue really does contain bare angle brackets, and a blanket rule would
+ * silently eat the rest of a line like "5 < 6 is true". */
+int subtitles_markup_len(const char *p)
+{
+    static const char *const tags[] = {
+        "<i>", "</i>", "<b>", "</b>", "<u>", "</u>",
+        "<br>", "<br/>", "<br />", NULL
+    };
+    for (int i = 0; tags[i]; i++) {
+        size_t n = strlen(tags[i]);
+        if (strncasecmp(p, tags[i], n) == 0) return (int)n;
+    }
+    /* <font color="#ffffff"> / </font> — attributes vary, so run to the '>'. */
+    if (!strncasecmp(p, "<font", 5) || !strncasecmp(p, "</font", 6)) {
+        const char *end = strchr(p, '>');
+        if (end) return (int)(end - p + 1);
+    }
+    return 0;
+}
+
+/* Cleans up a downloaded .srt so mplayer's classic bitmap renderer can show
+ * it as plain readable text.
+ *
+ * Two separate problems get handled here.
+ *
+ * Formatting codes: asking Jellyfin for Stream.srt converts the CONTAINER to
+ * SubRip, but not the dialogue text itself — an ASS/SSA source keeps its
+ * inline override blocks, so lines arrive looking like
+ * "{\an8}{\i1}Hello there{\i0}" and every one of those braces gets drawn
+ * on screen. \N (ASS hard line break) and \h (hard space) survive too, as do
+ * the <i>/<b>/<font> tags SubRip itself permits. None of that means anything
+ * to this renderer, so it is stripped rather than displayed. Confirmed on
+ * real hardware against a real server as the reason ASS subtitles looked
+ * like code.
+ *
+ * Non-ASCII: the font (src/font8x8.h) covers 0x00-0x7F only. Text is folded
+ * through the same transliteration used for titles, so "café" reads as
+ * "cafe" rather than as replacement blobs — a real improvement on the old
+ * behaviour here, which blanked every byte >= 0x80 and turned any accented
+ * word into gaps. */
+void subtitles_sanitize_srt(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    if (len <= 0 || len > 4 * 1024 * 1024) { fclose(f); return; }
+    fseek(f, 0, SEEK_SET);
+
+    char *raw = malloc((size_t)len + 1);
+    if (!raw) { fclose(f); return; }
+    size_t got = fread(raw, 1, (size_t)len, f);
+    fclose(f);
+    raw[got] = '\0';
+
+    /* Pass 1 — drop markup and override blocks, turn ASS escapes into real
+     * characters. Output is never longer than the input, so one buffer of the
+     * same size is always enough. */
+    char *stripped = malloc(got + 1);
+    if (!stripped) { free(raw); return; }
+
+    size_t o = 0;
+    /* Whether a line ends up empty has to be decided against the INPUT line,
+     * not the output: a line that was nothing but "{\an8}" strips to nothing,
+     * and emitting its newline anyway leaves a blank line — which is the cue
+     * separator in SubRip, so the cue would be cut in half and its dialogue
+     * lost. Tracking the line start lets such a line be rolled back entirely,
+     * while a line that was blank to begin with is a real separator and is
+     * kept. */
+    size_t line_start  = 0;   /* output offset where the current line began */
+    int    line_stripped = 0; /* something was removed from this line */
+    int    line_visible  = 0; /* something other than whitespace survived */
+
+    for (size_t i = 0; i < got; ) {
+        char c = raw[i];
+
+        if (c == '\n') {
+            /* Only lines that LOST content are candidates for removal. A line
+             * that was already blank — including the lone '\r' of a CRLF
+             * separator — is a real cue boundary and must survive. */
+            if (line_stripped && !line_visible) {
+                o = line_start;          /* drop the line, newline included */
+            } else {
+                stripped[o++] = '\n';
+                line_start = o;
+            }
+            line_stripped = line_visible = 0;
+            i++;
+            continue;
+        }
+
+        if (c == '{') {
+            /* Bounded to the current line: an unmatched '{' shouldn't be
+             * able to swallow the rest of the file. */
+            size_t j = i + 1;
+            while (j < got && raw[j] != '}' && raw[j] != '\n') j++;
+            if (j < got && raw[j] == '}') { line_stripped = 1; i = j + 1; continue; }
+        }
+        if (c == '<') {
+            int n = subtitles_markup_len(raw + i);
+            if (n) { line_stripped = 1; i += (size_t)n; continue; }
+        }
+        if (c == '\\' && i + 1 < got) {
+            char esc = raw[i + 1];
+            if (esc == 'N' || esc == 'n') {
+                /* An ASS hard break starts a new line, so the bookkeeping
+                 * has to roll over with it. */
+                stripped[o++] = '\n';
+                line_start = o;
+                line_stripped = line_visible = 0;
+                i += 2;
+                continue;
+            }
+            if (esc == 'h') { stripped[o++] = ' '; i += 2; continue; }
+        }
+
+        if (c != ' ' && c != '\t' && c != '\r') line_visible = 1;
+        stripped[o++] = c;
+        i++;
+    }
+    /* Same decision for a trailing line with no terminating newline. */
+    if (line_stripped && !line_visible) o = line_start;
+
+    stripped[o] = '\0';
+    free(raw);
+
+    /* Pass 2 — fold each line to ASCII independently, so the line structure
+     * SubRip depends on survives (jf_text_to_display flattens newlines to
+     * spaces, which would otherwise merge a cue's timing and text lines). */
+    FILE *out = fopen(path, "wb");
+    if (!out) { free(stripped); return; }
+
+    char *line = stripped;
+    while (line < stripped + o) {
+        char *nl = strchr(line, '\n');
+        if (nl) *nl = '\0';
+
+        size_t line_len = strlen(line);
+        if (line_len > 0 && line[line_len - 1] == '\r') line[--line_len] = '\0';
+
+        /* Folding can't empty a line that wasn't already empty — an
+         * untranslatable character becomes '?', not nothing — so pass 1's
+         * decision about which lines survive still stands. */
+        char folded[1024];
+        jf_text_to_display(line, folded, sizeof(folded));
+        fprintf(out, "%s\n", folded);
+
+        if (!nl) break;
+        line = nl + 1;
+    }
+
+    fclose(out);
+    free(stripped);
+}

--- a/src/subtitles.h
+++ b/src/subtitles.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/* Subtitle text clean-up, split out from main.c so it can be tested directly:
+ * it's pure text processing with no framebuffer or player involvement, and
+ * the failure mode (override codes drawn on screen as literal text) is only
+ * visible during playback, which is exactly the thing that can't be exercised
+ * off-hardware. */
+
+/* Rewrites a downloaded .srt in place so mplayer's classic bitmap renderer
+ * can display it as plain text:
+ *
+ *  - ASS/SSA inline override blocks ({\an8}, {\pos(..)}, {\i1}, ...) removed
+ *  - \N and \n turned into real line breaks, \h into a space
+ *  - <i>/<b>/<u>/<br>/<font ...> markup removed
+ *  - text folded to ASCII (see jf_text_to_display)
+ *  - lines left empty by the above dropped, so a cue isn't split in two by
+ *    an accidental blank line
+ *
+ * Cue numbering and "00:00:20,000 --> 00:00:24,400" timing lines pass through
+ * untouched. Silently does nothing if the file is missing, empty, or larger
+ * than a sane subtitle track. */
+void subtitles_sanitize_srt(const char *path);
+
+/* Length of a recognised inline markup tag at `p`, or 0 if there isn't one.
+ * Exposed for testing — the allowlist behaviour matters (a blanket
+ * '<' to '>' rule would eat dialogue containing a bare angle bracket). */
+int subtitles_markup_len(const char *p);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -1,0 +1,50 @@
+/* Unit tests for jf_config_load's handling of the optional transcode profile
+ * line — build and run with `make test`.
+ *
+ * The config file is positional, so anything matched by shape rather than by
+ * line number has to be pinned down: the risk isn't a profile that fails to
+ * parse, it's a malformed one being silently consumed as an API key (or an
+ * API key being eaten as a profile). Both directions are covered below.
+ *
+ * Writes and reads ./jellyfin.conf in the current directory, so run it
+ * somewhere disposable — the Makefile target uses a temp dir. */
+#include <stdio.h>
+#include <string.h>
+#include "jellyfin.h"
+static int fails = 0, checks = 0;
+static void t(const char *label, const char *body,
+              int ew, int eh, int erate, const char *ekey, const char *emode) {
+    FILE *f = fopen("./jellyfin.conf", "w"); fputs(body, f); fclose(f);
+    JfConfig c; jf_config_load(&c);
+    checks++;
+    int ok = c.profile_width == ew && c.profile_height == eh &&
+             c.profile_bitrate == erate && !strcmp(c.api_key, ekey) &&
+             !strcmp(c.tv_mode, emode);
+    if (!ok) { fails++;
+        printf("  FAIL %s\n    got %dx%d@%d key=\"%s\" mode=%s\n    want %dx%d@%d key=\"%s\" mode=%s\n",
+               label, c.profile_width, c.profile_height, c.profile_bitrate, c.api_key, c.tv_mode,
+               ew, eh, erate, ekey, emode);
+    }
+}
+int main(void) {
+    t("no profile -> defaults", "http://s:8096\nPAL\n",
+      480,270,8000000,"","PAL");
+    t("WxH only", "http://s:8096\n640x480\nNTSC\n",
+      640,480,8000000,"","NTSC");
+    t("WxH@rate", "http://s:8096\n720x480@12000000\nPAL\n",
+      720,480,12000000,"","PAL");
+    t("with api key + username", "http://s:8096\nkey123\nbob\n640x480@9000000\nPAL\n",
+      640,480,9000000,"key123","PAL");
+    t("profile before credentials", "http://s:8096\n640x480\nkey123\nbob\n",
+      640,480,8000000,"key123","PAL");
+    /* Out of range: rejected, defaults kept, and NOT read as an api key. */
+    t("too large -> ignored", "http://s:8096\n9999x9999\nPAL\n",
+      480,270,8000000,"","PAL");
+    t("bad bitrate -> size kept, rate default", "http://s:8096\n640x480@5\nPAL\n",
+      640,480,8000000,"","PAL");
+    /* Trailing junk must not parse, and must fall through to the api_key slot. */
+    t("trailing junk is a credential", "http://s:8096\n480x270junk\nbob\n",
+      480,270,8000000,"480x270junk","PAL");
+    printf("profile: %d checks, %d failures\n", checks, fails);
+    return fails ? 1 : 0;
+}

--- a/tests/test_json.c
+++ b/tests/test_json.c
@@ -1,0 +1,262 @@
+/* Unit tests for src/json.c — build and run with `make test`.
+ *
+ * The parser sits under every server response the client reads, so the cases
+ * that matter most here are the ones the old strstr-based scanner got wrong:
+ * \uXXXX escapes (Jellyfin escapes apostrophes and all non-ASCII that way),
+ * same-named keys nested inside sub-objects, and truncated input. */
+
+#include <stdio.h>
+#include <string.h>
+#include "json.h"
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(cond, ...) do {                                   \
+    checks++;                                                    \
+    if (!(cond)) {                                               \
+        failures++;                                              \
+        printf("  FAIL %s:%d: ", __func__, __LINE__);            \
+        printf(__VA_ARGS__);                                     \
+        printf("\n");                                            \
+    }                                                            \
+} while (0)
+
+#define CHECK_STR(doc, from, path, expect) do {                          \
+    const char *got_ = json_as_str(json_find(doc, from, path), "(none)"); \
+    CHECK(strcmp(got_, expect) == 0,                                     \
+          "%s: expected \"%s\", got \"%s\"", path, expect, got_);        \
+} while (0)
+
+/* json_parse mutates its input, so every case needs its own writable copy. */
+static char scratch[16384];
+static char *dup_json(const char *src)
+{
+    strncpy(scratch, src, sizeof(scratch) - 1);
+    scratch[sizeof(scratch) - 1] = '\0';
+    return scratch;
+}
+
+static void test_scalars(void)
+{
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(
+        "{\"s\":\"hi\",\"n\":42,\"neg\":-7,\"f\":3.5,\"t\":true,\"no\":false,\"nul\":null}")),
+        "parse failed");
+
+    CHECK_STR(&doc, NULL, "s", "hi");
+    CHECK(json_as_i64(json_find(&doc, NULL, "n"), -1) == 42, "int");
+    CHECK(json_as_i64(json_find(&doc, NULL, "neg"), 0) == -7, "negative int");
+    CHECK(json_as_dbl(json_find(&doc, NULL, "f"), 0) == 3.5, "double");
+    CHECK(json_as_bool(json_find(&doc, NULL, "t"), 0) == 1, "true");
+    CHECK(json_as_bool(json_find(&doc, NULL, "no"), 1) == 0, "false");
+    CHECK(json_find(&doc, NULL, "nul")->type == JSON_NULL, "null");
+
+    /* A missing key and a wrong-typed key both fall back, so callers never
+     * need a separate presence check. */
+    CHECK(json_as_i64(json_find(&doc, NULL, "absent"), 99) == 99, "missing fallback");
+    CHECK(json_as_i64(json_find(&doc, NULL, "s"), 99) == 99, "wrong-type fallback");
+    json_free(&doc);
+}
+
+static void test_large_integers(void)
+{
+    /* RunTimeTicks are ~10^11..10^14. These must survive exactly, which is
+     * why numbers carry an int64 alongside the double. */
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(
+        "{\"RunTimeTicks\":72000000000,\"Pos\":13800000001}")), "parse failed");
+    CHECK(json_as_i64(json_find(&doc, NULL, "RunTimeTicks"), 0) == 72000000000LL,
+          "runtime ticks");
+    CHECK(json_as_i64(json_find(&doc, NULL, "Pos"), 0) == 13800000001LL,
+          "odd tick value survives exactly");
+    json_free(&doc);
+}
+
+static void test_escapes(void)
+{
+    JsonDoc doc;
+    /* Exactly what Jellyfin puts on the wire — confirmed against a real
+     * server: the apostrophe in "Don't Look Up" arrives as '. */
+    CHECK(json_parse(&doc, dup_json(
+        "{\"a\":\"Don\\u0027t Look Up\","
+        "\"b\":\"Am\\u00e9lie\","
+        "\"c\":\"tab\\there\","
+        "\"d\":\"quote\\\"inside\","
+        "\"e\":\"back\\\\slash\","
+        "\"f\":\"\\u0041\\u0042\"}")), "parse failed");
+
+    CHECK_STR(&doc, NULL, "a", "Don't Look Up");
+    CHECK_STR(&doc, NULL, "b", "Am\xC3\xA9lie");       /* U+00E9 as UTF-8 */
+    CHECK_STR(&doc, NULL, "c", "tab\there");
+    CHECK_STR(&doc, NULL, "d", "quote\"inside");
+    CHECK_STR(&doc, NULL, "e", "back\\slash");
+    CHECK_STR(&doc, NULL, "f", "AB");
+    json_free(&doc);
+}
+
+static void test_surrogate_pairs(void)
+{
+    JsonDoc doc;
+    /* U+1F600, the shape an emoji in a title arrives in. */
+    CHECK(json_parse(&doc, dup_json("{\"e\":\"x\\ud83d\\ude00y\"}")), "parse failed");
+    CHECK_STR(&doc, NULL, "e", "x\xF0\x9F\x98\x80y");
+    json_free(&doc);   /* required before reusing the doc — see json_parse's contract */
+
+    /* An unpaired high surrogate is not a code point — substituted rather
+     * than emitted as invalid bytes. */
+    CHECK(json_parse(&doc, dup_json("{\"e\":\"x\\ud83dy\"}")), "lone surrogate parse");
+    CHECK_STR(&doc, NULL, "e", "x\xEF\xBF\xBDy");
+    json_free(&doc);
+}
+
+static void test_nested_key_shadowing(void)
+{
+    /* The case that motivated replacing the scanner. "Type" appears both on
+     * the item and on every entry of its People array; a flat search finds
+     * whichever comes first in the byte stream, which is only correct by
+     * accident of C# property declaration order upstream. */
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(
+        "{\"People\":[{\"Name\":\"An Actor\",\"Type\":\"Actor\"}],"
+        "\"Type\":\"Movie\",\"Name\":\"The Film\"}")), "parse failed");
+
+    CHECK_STR(&doc, NULL, "Type", "Movie");
+    CHECK_STR(&doc, NULL, "Name", "The Film");
+    CHECK_STR(&doc, NULL, "People[0].Type", "Actor");
+    CHECK_STR(&doc, NULL, "People[0].Name", "An Actor");
+    json_free(&doc);
+}
+
+static void test_paths_and_arrays(void)
+{
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(
+        "{\"ImageTags\":{\"Primary\":\"abc123\",\"Logo\":\"def456\"},"
+        "\"BackdropImageTags\":[\"bd0\",\"bd1\"],"
+        "\"MediaStreams\":[{\"Index\":0,\"Type\":\"Video\"},"
+                          "{\"Index\":1,\"Type\":\"Audio\",\"Language\":\"eng\"}]}")),
+        "parse failed");
+
+    CHECK_STR(&doc, NULL, "ImageTags.Primary", "abc123");
+    CHECK_STR(&doc, NULL, "ImageTags.Logo", "def456");
+    CHECK_STR(&doc, NULL, "BackdropImageTags[0]", "bd0");
+    CHECK_STR(&doc, NULL, "BackdropImageTags[1]", "bd1");
+    CHECK_STR(&doc, NULL, "MediaStreams[1].Language", "eng");
+    CHECK(json_as_i64(json_find(&doc, NULL, "MediaStreams[1].Index"), -1) == 1, "nested index");
+    CHECK(json_find(&doc, NULL, "BackdropImageTags[9]") == NULL, "out-of-range element");
+    CHECK(json_find(&doc, NULL, "ImageTags.Missing") == NULL, "missing nested key");
+
+    const JsonNode *streams = json_find(&doc, NULL, "MediaStreams");
+    CHECK(streams && streams->child_count == 2, "array length");
+
+    int seen = 0;
+    JSON_FOREACH(&doc, streams, s) seen++;
+    CHECK(seen == 2, "iteration count, got %d", seen);
+    json_free(&doc);
+}
+
+static void test_relative_lookup(void)
+{
+    /* Iterating a list and reading fields relative to each element is the
+     * core browse-list access pattern. */
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(
+        "{\"Items\":[{\"Name\":\"One\",\"Id\":\"1\"},{\"Name\":\"Two\",\"Id\":\"2\"}],"
+        "\"TotalRecordCount\":503}")), "parse failed");
+
+    CHECK(json_as_i64(json_find(&doc, NULL, "TotalRecordCount"), 0) == 503, "total");
+
+    const JsonNode *items = json_find(&doc, NULL, "Items");
+    const char *names[2] = {0};
+    int i = 0;
+    JSON_FOREACH(&doc, items, it) {
+        if (i < 2) names[i] = json_as_str(json_find(&doc, it, "Name"), "?");
+        i++;
+    }
+    CHECK(i == 2, "two items");
+    CHECK(names[0] && strcmp(names[0], "One") == 0, "first name");
+    CHECK(names[1] && strcmp(names[1], "Two") == 0, "second name");
+    json_free(&doc);
+}
+
+static void test_malformed_input(void)
+{
+    /* Truncation is the important one: the old scanner turned a response cut
+     * short by a too-small buffer into a plausible short list. It must fail. */
+    const char *bad[] = {
+        "{\"Items\":[{\"Name\":\"trunc",      /* cut mid-string */
+        "{\"Items\":[{\"Name\":\"x\"}",       /* cut mid-array */
+        "{\"a\":}",
+        "{\"a\" 1}",
+        "{a:1}",
+        "[1,2,",
+        "{\"a\":01x}",
+        "",
+        "{\"a\":1}trailing",
+        NULL
+    };
+    for (int i = 0; bad[i]; i++) {
+        JsonDoc doc;
+        CHECK(json_parse(&doc, dup_json(bad[i])) == 0,
+              "expected rejection of: %s", bad[i]);
+        json_free(&doc);
+    }
+
+    /* Empty containers are valid, not malformed. */
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json("{\"Items\":[],\"TotalRecordCount\":0}")),
+          "empty array should parse");
+    CHECK(json_find(&doc, NULL, "Items")->child_count == 0, "empty array length");
+    json_free(&doc);
+}
+
+static void test_deep_nesting_guard(void)
+{
+    /* Bounded recursion — a deliberately over-nested document must be
+     * rejected rather than run the stack out. */
+    char deep[512];
+    int n = 0;
+    for (; n < 200; n++) deep[n] = '[';
+    deep[n] = '\0';
+
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json(deep)) == 0, "deep nesting should be rejected");
+    json_free(&doc);
+}
+
+static void test_copy_str(void)
+{
+    JsonDoc doc;
+    CHECK(json_parse(&doc, dup_json("{\"Name\":\"A Fairly Long Title Here\"}")),
+          "parse failed");
+
+    char buf[8];
+    CHECK(json_copy_str(&doc, NULL, "Name", buf, sizeof(buf)) == 1, "copy ok");
+    CHECK(strcmp(buf, "A Fairl") == 0, "truncated safely, got \"%s\"", buf);
+    CHECK(buf[sizeof(buf) - 1] == '\0', "NUL terminated");
+
+    /* A miss must clear the buffer rather than leave stale content, so a
+     * caller reusing one struct can't inherit a previous item's value. */
+    strcpy(buf, "stale");
+    CHECK(json_copy_str(&doc, NULL, "Absent", buf, sizeof(buf)) == 0, "miss returns 0");
+    CHECK(buf[0] == '\0', "miss clears the buffer");
+    json_free(&doc);
+}
+
+int main(void)
+{
+    test_scalars();
+    test_large_integers();
+    test_escapes();
+    test_surrogate_pairs();
+    test_nested_key_shadowing();
+    test_paths_and_arrays();
+    test_relative_lookup();
+    test_malformed_input();
+    test_deep_nesting_guard();
+    test_copy_str();
+
+    printf("json: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/test_subtitles.c
+++ b/tests/test_subtitles.c
@@ -1,0 +1,197 @@
+/* Unit tests for src/subtitles.c — build and run with `make test`.
+ *
+ * Subtitles only render during playback, which can't be exercised off
+ * hardware (mplayer writes into a real framebuffer), so this is the only
+ * place the clean-up can actually be checked. The inputs below are the shapes
+ * Jellyfin really returns: asking for Stream.srt converts the container to
+ * SubRip but leaves ASS/SSA inline override codes in the dialogue text. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "subtitles.h"
+
+static int failures = 0;
+static int checks   = 0;
+
+#define CHECK(cond, ...) do {                          \
+    checks++;                                           \
+    if (!(cond)) {                                      \
+        failures++;                                     \
+        printf("  FAIL %s:%d: ", __func__, __LINE__);   \
+        printf(__VA_ARGS__);                            \
+        printf("\n");                                   \
+    }                                                   \
+} while (0)
+
+static const char *TMP = "/tmp/misterfin_test_sub.srt";
+
+/* Runs the sanitiser over `input` and returns the result in a static buffer. */
+static const char *sanitize(const char *input)
+{
+    static char out[8192];
+    FILE *f = fopen(TMP, "wb");
+    if (!f) { out[0] = '\0'; return out; }
+    fwrite(input, 1, strlen(input), f);
+    fclose(f);
+
+    subtitles_sanitize_srt(TMP);
+
+    f = fopen(TMP, "rb");
+    if (!f) { out[0] = '\0'; return out; }
+    size_t n = fread(out, 1, sizeof(out) - 1, f);
+    fclose(f);
+    out[n] = '\0';
+    return out;
+}
+
+#define CHECK_EQ(got, expect) do {                                    \
+    const char *g_ = (got);                                            \
+    checks++;                                                          \
+    if (strcmp(g_, expect) != 0) {                                     \
+        failures++;                                                    \
+        printf("  FAIL %s:%d\n    expected: %s\n    got:      %s\n",   \
+               __func__, __LINE__, expect, g_);                        \
+    }                                                                  \
+} while (0)
+
+static void test_ass_override_blocks(void)
+{
+    /* The reported bug: an ASS source converted to SRT keeps {\...} blocks,
+     * and every brace was being drawn on screen as literal text. */
+    CHECK_EQ(sanitize(
+        "1\n"
+        "00:00:20,000 --> 00:00:24,400\n"
+        "{\\an8}{\\i1}Hello there{\\i0}\n"
+        "\n"),
+        "1\n"
+        "00:00:20,000 --> 00:00:24,400\n"
+        "Hello there\n"
+        "\n");
+
+    /* Positioning and colour codes mid-line. */
+    CHECK_EQ(sanitize("{\\pos(400,570)}Watch out{\\c&H0000FF&} behind you\n"),
+                      "Watch out behind you\n");
+}
+
+static void test_line_of_only_codes_is_dropped(void)
+{
+    /* A line that was nothing but override codes becomes empty — and an
+     * empty line is the cue separator in SubRip, so emitting it would cut
+     * the cue in half and lose the dialogue. */
+    CHECK_EQ(sanitize(
+        "1\n"
+        "00:00:01,000 --> 00:00:02,000\n"
+        "{\\an8}\n"
+        "Real dialogue\n"
+        "\n"),
+        "1\n"
+        "00:00:01,000 --> 00:00:02,000\n"
+        "Real dialogue\n"
+        "\n");
+}
+
+static void test_ass_escapes(void)
+{
+    CHECK_EQ(sanitize("First\\NSecond\n"), "First\nSecond\n");
+    CHECK_EQ(sanitize("Hard\\hspace\n"),   "Hard space\n");
+}
+
+static void test_html_markup(void)
+{
+    CHECK_EQ(sanitize("<i>Italic</i> and <b>bold</b>\n"), "Italic and bold\n");
+    CHECK_EQ(sanitize("<font color=\"#ffffff\">Coloured</font>\n"), "Coloured\n");
+    CHECK_EQ(sanitize("Line one<br>Line two\n"), "Line oneLine two\n");
+
+    /* Allowlisted on purpose: a bare '<' in dialogue must survive. A
+     * strip-to-'>' rule would eat the rest of the line here. */
+    CHECK_EQ(sanitize("5 < 6 is true\n"), "5 < 6 is true\n");
+    CHECK(subtitles_markup_len("<notatag>") == 0, "unknown tag not consumed");
+    CHECK(subtitles_markup_len("<i>") == 3, "<i> length");
+    CHECK(subtitles_markup_len("</font color>") == 13, "</font ...> runs to '>'");
+}
+
+static void test_timing_lines_survive(void)
+{
+    /* "-->" contains '>' and the timing line must pass through byte for byte,
+     * or every cue loses its timing. */
+    const char *out = sanitize(
+        "42\n"
+        "01:02:03,456 --> 01:02:05,789\n"
+        "Text\n"
+        "\n");
+    CHECK(strstr(out, "01:02:03,456 --> 01:02:05,789") != NULL,
+          "timing line intact, got: %s", out);
+    CHECK(strstr(out, "42\n") == out, "cue number intact");
+}
+
+static void test_non_ascii_folding(void)
+{
+    /* Previously every byte >= 0x80 was blanked, so an accented word turned
+     * into gaps. Folding keeps it readable on an ASCII-only font. */
+    CHECK_EQ(sanitize("Caf\xC3\xA9 na\xC3\xAF ve\n"), "Cafe nai ve\n");
+    /* U+266A MUSIC NOTE — common in subtitles to mark background music. It
+     * has no ASCII equivalent, so it becomes a single '?'. */
+    CHECK_EQ(sanitize("\xE2\x99\xAA\n"), "?\n");
+}
+
+static void test_structure_preserved(void)
+{
+    /* A full two-cue file end to end. */
+    CHECK_EQ(sanitize(
+        "1\n"
+        "00:00:01,000 --> 00:00:02,000\n"
+        "{\\i1}First cue{\\i0}\n"
+        "\n"
+        "2\n"
+        "00:00:03,000 --> 00:00:04,000\n"
+        "Second cue\n"
+        "\n"),
+        "1\n"
+        "00:00:01,000 --> 00:00:02,000\n"
+        "First cue\n"
+        "\n"
+        "2\n"
+        "00:00:03,000 --> 00:00:04,000\n"
+        "Second cue\n"
+        "\n");
+}
+
+static void test_crlf_input(void)
+{
+    /* Plenty of subtitle files are CRLF; a stray \r would draw as a glyph. */
+    CHECK_EQ(sanitize("1\r\n00:00:01,000 --> 00:00:02,000\r\nText\r\n\r\n"),
+                      "1\n00:00:01,000 --> 00:00:02,000\nText\n\n");
+}
+
+static void test_degenerate_input(void)
+{
+    /* Unterminated brace must not swallow the file — it's bounded to the
+     * line, so the text after the newline still comes through. */
+    const char *out = sanitize("{\\an8 unterminated\nSurvivor\n");
+    CHECK(strstr(out, "Survivor") != NULL, "text after a stray '{' survives, got: %s", out);
+
+    CHECK_EQ(sanitize(""), "");
+
+    /* A missing file is a no-op, not a crash. */
+    remove(TMP);
+    subtitles_sanitize_srt(TMP);
+    checks++;
+}
+
+int main(void)
+{
+    test_ass_override_blocks();
+    test_line_of_only_codes_is_dropped();
+    test_ass_escapes();
+    test_html_markup();
+    test_timing_lines_survive();
+    test_non_ascii_folding();
+    test_structure_preserved();
+    test_crlf_input();
+    test_degenerate_input();
+
+    remove(TMP);
+    printf("subtitles: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tools/mock-jellyfin.py
+++ b/tools/mock-jellyfin.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+A tiny fake Jellyfin server for developing MiSTerFin off-hardware.
+
+Serves just enough of the API for the client to browse, page, and
+authenticate against, backed by a synthetic library that is deliberately
+bigger than any fixed client-side buffer — 500 movies, so pagination has
+something real to page through, which a small personal library wouldn't
+exercise.
+
+Stdlib only (http.server + zlib for the placeholder cover art). No
+dependencies, and nothing here talks to a real server or real credentials.
+
+Usage:
+    python3 tools/mock-jellyfin.py [port]        # default 8096
+
+Then point ./jellyfin.conf at it:
+    http://127.0.0.1:8096
+    mock-api-key
+    mockuser
+    PAL
+"""
+
+import json
+import re
+import struct
+import sys
+import zlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+USER_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+USER_NAME = "mockuser"
+
+# Deliberately > 256 (the client's JF_MAX_ITEMS) so paging past the end of a
+# single window is reachable, and not a round number so off-by-ones show up.
+N_MOVIES = 503
+N_SERIES = 30
+SEASONS_PER_SERIES = 2
+EPISODES_PER_SEASON = 10
+N_ARTISTS = 20
+ALBUMS_PER_ARTIST = 3
+TRACKS_PER_ALBUM = 10
+
+TICKS_PER_MIN = 60 * 10_000_000
+
+
+def dotnet_escape(text):
+    """Makes json.dumps output match what Jellyfin actually puts on the wire.
+
+    Jellyfin configures no custom Encoder (see JsonDefaults.cs), so
+    System.Text.Json uses JavaScriptEncoder.Default — which escapes every
+    non-ASCII character AND the HTML-sensitive set below as \\uXXXX. Python's
+    ensure_ascii=True covers the non-ASCII half; these are the rest.
+
+    This matters for client testing far more than it looks: an apostrophe is
+    escaped, so a perfectly ordinary title like "Don't Look Up" arrives as
+    "Don\\u0027t Look Up". A mock that didn't do this would make a client's
+    escape handling look correct when it isn't.
+    """
+    for ch in ("'", "<", ">", "&", "+"):
+        text = text.replace(ch, "\\u%04x" % ord(ch))
+    return text
+
+
+def _png(r, g, b, w=8, h=8):
+    """Smallest useful solid-colour PNG — same from-scratch encoder approach
+    as tools/raw_to_png.py, for the same reason (no image library assumed)."""
+    raw = b"".join(b"\x00" + bytes((r, g, b)) * w for _ in range(h))
+
+    def chunk(tag, payload):
+        return (struct.pack(">I", len(payload)) + tag + payload +
+                struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF))
+
+    return (b"\x89PNG\r\n\x1a\n" +
+            chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0)) +
+            chunk(b"IDAT", zlib.compress(raw, 9)) +
+            chunk(b"IEND", b""))
+
+
+# A few distinct colours so the cover grid and browse panel are visibly
+# populated rather than uniformly grey.
+COVERS = [_png(200, 60, 60), _png(60, 160, 200), _png(200, 170, 60),
+          _png(120, 90, 200), _png(70, 190, 120)]
+
+VIEWS = [
+    {"Id": "view-movies", "Name": "Movies",   "CollectionType": "movies"},
+    {"Id": "view-tv",     "Name": "TV Shows", "CollectionType": "tvshows"},
+    {"Id": "view-music",  "Name": "Music",    "CollectionType": "music"},
+]
+
+
+def base_item(item_id, name, item_type, **extra):
+    item = {
+        "Id": item_id,
+        "Name": name,
+        "Type": item_type,
+        "ServerId": "mockserver",
+        "ImageTags": {"Primary": "tag-" + item_id},
+        "BackdropImageTags": ["backdrop-" + item_id],
+        "UserData": {"PlaybackPositionTicks": 0, "Played": False, "PlayCount": 0},
+    }
+    item.update(extra)
+    return item
+
+
+def build_library():
+    """One flat dict of every item, plus parent->children ordering."""
+    items, children = {}, {}
+
+    # Titles the real server will escape as \uXXXX: System.Text.Json's default
+    # encoder escapes apostrophes and every non-ASCII character, so these are
+    # what an ordinary library actually looks like over the wire.
+    tricky = [
+        "Don't Look Up", "Amélie", "A Fistful of Dollars — Extended",
+        "Spinal Tap: This Is It", "Zoë & Co.", "Æon Flux",
+    ]
+
+    movies = []
+    for idx, title in enumerate(tricky):
+        mid = f"movie-tricky-{idx}"
+        items[mid] = base_item(mid, title, "Movie",
+                               ProductionYear=2000 + idx,
+                               RunTimeTicks=100 * TICKS_PER_MIN)
+        movies.append(mid)
+
+    for i in range(N_MOVIES):
+        mid = f"movie-{i:04d}"
+        # A handful get watched/resume state so those badges are exercised.
+        user_data = {"PlaybackPositionTicks": 0, "Played": False, "PlayCount": 0}
+        if i % 17 == 0:
+            user_data = {"PlaybackPositionTicks": 0, "Played": True, "PlayCount": 1}
+        elif i % 11 == 0:
+            user_data = {"PlaybackPositionTicks": 23 * TICKS_PER_MIN,
+                         "Played": False, "PlayCount": 0}
+        items[mid] = base_item(
+            mid, f"Movie {i:04d} The Motion Picture", "Movie",
+            ProductionYear=1980 + (i % 45),
+            RunTimeTicks=(90 + i % 50) * TICKS_PER_MIN,
+            Overview=f"Synthetic movie #{i} used for client testing. " * 4,
+            CommunityRating=round(4.0 + (i % 60) / 10.0, 1),
+            UserData=user_data)
+        movies.append(mid)
+    stress_id = "movie-stress"
+    items[stress_id] = base_item(stress_id, "Stress Test Many Tracks", "Movie",
+                                 ProductionYear=2024, RunTimeTicks=120 * TICKS_PER_MIN)
+    movies.append(stress_id)
+
+    children["view-movies"] = movies
+
+    series_ids = []
+    for s in range(N_SERIES):
+        sid = f"series-{s:03d}"
+        n_eps = SEASONS_PER_SERIES * EPISODES_PER_SEASON
+        items[sid] = base_item(
+            sid, f"Series {s:03d}", "Series",
+            ProductionYear=1995 + (s % 30),
+            ChildCount=SEASONS_PER_SERIES,      # season count
+            RecursiveItemCount=n_eps,           # episode count, batched server-side
+            Overview=f"Synthetic series #{s}. " * 6)
+        series_ids.append(sid)
+
+        season_ids = []
+        for se in range(1, SEASONS_PER_SERIES + 1):
+            season_id = f"{sid}-s{se}"
+            items[season_id] = base_item(season_id, f"Season {se}", "Season",
+                                         IndexNumber=se, ChildCount=EPISODES_PER_SEASON)
+            season_ids.append(season_id)
+
+            ep_ids = []
+            for e in range(1, EPISODES_PER_SEASON + 1):
+                eid = f"{season_id}e{e:02d}"
+                items[eid] = base_item(
+                    eid, f"Episode {e:02d}", "Episode",
+                    IndexNumber=e, ParentIndexNumber=se,
+                    RunTimeTicks=42 * TICKS_PER_MIN,
+                    SeriesId=sid, SeriesName=f"Series {s:03d}",
+                    ParentBackdropItemId=sid,
+                    ParentBackdropImageTags=["backdrop-" + sid],
+                    ParentLogoItemId=sid, ParentLogoImageTag="logo-" + sid,
+                    Overview=f"Synthetic episode S{se}E{e}. " * 4)
+                ep_ids.append(eid)
+            children[season_id] = ep_ids
+        children[sid] = season_ids
+    children["view-tv"] = series_ids
+
+    artist_ids = []
+    for a in range(N_ARTISTS):
+        aid = f"artist-{a:03d}"
+        items[aid] = base_item(aid, f"Artist {a:03d}", "MusicArtist",
+                               ChildCount=ALBUMS_PER_ARTIST)
+        artist_ids.append(aid)
+
+        album_ids = []
+        for al in range(ALBUMS_PER_ARTIST):
+            alid = f"{aid}-album{al}"
+            items[alid] = base_item(alid, f"Album {al} by Artist {a:03d}", "MusicAlbum",
+                                    ProductionYear=1990 + ((a + al) % 35),
+                                    ChildCount=TRACKS_PER_ALBUM,
+                                    RecursiveItemCount=TRACKS_PER_ALBUM)
+            album_ids.append(alid)
+
+            track_ids = []
+            for t in range(1, TRACKS_PER_ALBUM + 1):
+                tid = f"{alid}-t{t:02d}"
+                items[tid] = base_item(
+                    tid, f"Track {t:02d}", "Audio",
+                    IndexNumber=t, RunTimeTicks=(3 + t % 4) * TICKS_PER_MIN,
+                    Album=f"Album {al} by Artist {a:03d}",
+                    AlbumArtist=f"Artist {a:03d}",
+                    AlbumId=alid, AlbumPrimaryImageTag="tag-" + alid)
+                track_ids.append(tid)
+            children[alid] = track_ids
+        children[aid] = album_ids
+    children["view-music"] = artist_ids
+
+    return items, children
+
+
+ITEMS, CHILDREN = build_library()
+
+
+def descendants(parent_id, kinds=None):
+    """Every item under parent_id, optionally filtered to BaseItemKinds."""
+    out, stack = [], list(CHILDREN.get(parent_id, []))
+    while stack:
+        item_id = stack.pop(0)
+        item = ITEMS.get(item_id)
+        if not item:
+            continue
+        if kinds is None or item["Type"] in kinds:
+            out.append(item_id)
+        stack = list(CHILDREN.get(item_id, [])) + stack
+    return out
+
+
+def media_streams(item_id=""):
+    """Multiple audio tracks and a mix of text/image subtitles, so the track
+    pickers have something non-trivial to show.
+
+    An item id containing "stress" instead returns the maximum the client
+    stores (JF_MAX_SUBS / JF_MAX_AUDIO = 8 each), which is what the track
+    picker has to stay on screen for — the menu box is sized from its content,
+    so the full list on a 240-line NTSC frame is the case that overflows."""
+    if "stress" in item_id:
+        streams = [{"Index": 0, "Type": "Video", "Codec": "h264", "Width": 1920,
+                    "Height": 1080, "BitRate": 8_000_000, "AspectRatio": "16:9"}]
+        langs = ["eng", "jpn", "fra", "deu", "spa", "ita", "por", "rus"]
+        for n, lang in enumerate(langs):
+            streams.append({"Index": 1 + n, "Type": "Audio", "Codec": "ac3",
+                            "Language": lang, "Channels": 6, "IsDefault": n == 0,
+                            "DisplayTitle": f"{lang.upper()} - Dolby Digital 5.1 - Default"})
+        for n, lang in enumerate(langs):
+            streams.append({"Index": 9 + n, "Type": "Subtitle", "Codec": "subrip",
+                            "Language": lang,
+                            "DisplayTitle": f"{lang.upper()} - SUBRIP - External"})
+        return streams
+
+    return [
+        {"Index": 0, "Type": "Video", "Codec": "h264", "Width": 1920,
+         "Height": 1080, "BitRate": 8_000_000, "AspectRatio": "16:9",
+         "DisplayTitle": "1080p H264"},
+        {"Index": 1, "Type": "Audio", "Codec": "ac3", "Language": "eng",
+         "Channels": 6, "IsDefault": True,
+         "DisplayTitle": "English - Dolby Digital 5.1 - Default"},
+        {"Index": 2, "Type": "Audio", "Codec": "aac", "Language": "jpn",
+         "Channels": 2, "IsDefault": False, "DisplayTitle": "Japanese - AAC - Stereo"},
+        {"Index": 3, "Type": "Audio", "Codec": "aac", "Language": "eng",
+         "Channels": 2, "IsDefault": False,
+         "DisplayTitle": "English - AAC - Stereo - Commentary"},
+        # Two English subtitle tracks — dialogue and signs/songs — which is
+        # the case a bare language code can't distinguish. DisplayTitle is
+        # composed by the server exactly as below: the track's own Title
+        # first, then Forced/Default/codec/External as they apply.
+        {"Index": 4, "Type": "Subtitle", "Codec": "subrip", "Language": "eng",
+         "IsDefault": True, "IsForced": False,
+         "DisplayTitle": "English - Default - SUBRIP"},
+        {"Index": 5, "Type": "Subtitle", "Codec": "ass", "Language": "eng",
+         "Title": "Signs & Songs", "IsDefault": False, "IsForced": True,
+         "DisplayTitle": "Signs & Songs - English - Forced - ASS"},
+        {"Index": 6, "Type": "Subtitle", "Codec": "subrip", "Language": "eng",
+         "IsHearingImpaired": True, "IsDefault": False, "IsForced": False,
+         "DisplayTitle": "English - Hearing Impaired - SUBRIP"},
+        {"Index": 7, "Type": "Subtitle", "Codec": "pgssub", "Language": "jpn",
+         "DisplayTitle": "Japanese - PGSSUB"},
+    ]
+
+
+def people():
+    return [{"Id": f"person-{i}", "Name": f"Actor {i}", "Role": f"Character {i}",
+             "Type": "Actor", "PrimaryImageTag": f"tag-person-{i}"} for i in range(6)]
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # ── plumbing ────────────────────────────────────────────────────────────
+    def log_message(self, fmt, *args):
+        if "-v" in sys.argv:
+            sys.stderr.write("%s %s\n" % (self.command, self.path))
+
+    def _token(self):
+        """Extracts Token="..." from the MediaBrowser Authorization header."""
+        header = self.headers.get("Authorization", "")
+        m = re.search(r'Token="([^"]*)"', header)
+        return m.group(1) if m else ""
+
+    def _authorized(self):
+        """Real Jellyfin rejects an unknown or revoked token with 401, and the
+        client depends on that: it's how a saved token that the server has
+        since forgotten gets detected and replaced by a fresh Quick Connect,
+        rather than the app appearing to work while every request fails.
+        A mock that accepted anything would make that path untestable."""
+        return self._token() in VALID_TOKENS
+
+    def _send_401(self):
+        return self._send({"Error": "invalid token"}, status=401)
+
+    def _send(self, payload, content_type="application/json", status=200):
+        if isinstance(payload, (dict, list)):
+            # Compact separators on purpose: real Jellyfin sets
+            # WriteIndented = false, and a client that scans the raw bytes
+            # would behave differently against pretty-printed output.
+            text = json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+            payload = dotnet_escape(text).encode()
+        elif isinstance(payload, str):
+            payload = payload.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _query_result(self, ids, query):
+        """Applies StartIndex/Limit the way the real server does, and always
+        reports the untruncated TotalRecordCount — that total is the whole
+        point for a paging client."""
+        total = len(ids)
+        start = int(query.get("StartIndex", query.get("startIndex", [0]))[0])
+        limit = query.get("Limit", query.get("limit", [None]))[0]
+        window = ids[start:]
+        if limit is not None:
+            window = window[:int(limit)]
+        return {"Items": [ITEMS[i] for i in window],
+                "TotalRecordCount": total,
+                "StartIndex": start}
+
+    # ── routes ──────────────────────────────────────────────────────────────
+    def do_GET(self):
+        url = urlparse(self.path)
+        path, query = url.path, parse_qs(url.query)
+
+        # Everything needs a credential except the Quick Connect handshake
+        # (which is how you get one) and image requests — real Jellyfin serves
+        # artwork without auth, and the client relies on that: it fetches
+        # covers with a bare curl that sends no Authorization header at all.
+        exempt = path.startswith("/QuickConnect/") or "/Images/" in path
+        if not exempt and not self._authorized():
+            return self._send_401()
+
+        if path == "/Users":
+            return self._send([{"Id": USER_ID, "Name": USER_NAME}])
+
+        if path == "/UserViews":
+            views = [base_item(v["Id"], v["Name"], "CollectionFolder",
+                               CollectionType=v["CollectionType"]) for v in VIEWS]
+            return self._send({"Items": views, "TotalRecordCount": len(views)})
+
+        if path == "/QuickConnect/Enabled":
+            return self._send("true")
+
+        if path == "/QuickConnect/Connect":
+            secret = query.get("secret", [""])[0]
+            state = QUICK_CONNECT.get(secret)
+            if state is None:
+                return self._send({"Error": "Unknown secret"}, status=404)
+            # Auto-approves after a few polls so an unattended run completes;
+            # a real server waits for the user to type the code.
+            state["Polls"] += 1
+            if state["Polls"] >= 3:
+                state["Authenticated"] = True
+            return self._send(state)
+
+        m = re.match(r"^/Items/([^/]+)/Images/([^/?]+)", path)
+        if m:
+            return self._send(COVERS[hash(m.group(1)) % len(COVERS)], "image/png")
+
+        m = re.match(r"^/Shows/([^/]+)/Seasons$", path)
+        if m:
+            return self._send(self._query_result(CHILDREN.get(m.group(1), []), query))
+
+        m = re.match(r"^/Shows/([^/]+)/Episodes$", path)
+        if m:
+            season = query.get("seasonId", [None])[0]
+            ids = CHILDREN.get(season, []) if season else descendants(m.group(1), {"Episode"})
+            return self._send(self._query_result(ids, query))
+
+        if path == "/Shows/NextUp":
+            # First unwatched episode of each series, mimicking the real thing
+            # closely enough for the client's purposes.
+            ids = [descendants(s, {"Episode"})[0] for s in CHILDREN["view-tv"][:12]]
+            return self._send(self._query_result(ids, query))
+
+        if path == "/UserItems/Resume":
+            ids = [i for i in CHILDREN["view-movies"]
+                   if ITEMS[i]["UserData"]["PlaybackPositionTicks"] > 0][:12]
+            return self._send(self._query_result(ids, query))
+
+        m = re.match(r"^/Items/([^/?]+)$", path)
+        if m and m.group(1) in ITEMS:
+            item = dict(ITEMS[m.group(1)])
+            item["MediaStreams"] = media_streams(m.group(1))
+            item["People"] = people()
+            item["ImageTags"] = dict(item.get("ImageTags", {}))
+            item["ImageTags"]["Logo"] = "logo-" + m.group(1)
+            return self._send(item)
+
+        if path == "/Items":
+            parent = query.get("ParentId", query.get("parentId", [None]))[0]
+            recursive = query.get("Recursive", ["false"])[0].lower() == "true"
+            kinds = query.get("IncludeItemTypes", [None])[0]
+            kinds = set(kinds.split(",")) if kinds else None
+
+            if parent is None:
+                ids = []
+            elif recursive:
+                ids = descendants(parent, kinds)
+            else:
+                ids = [i for i in CHILDREN.get(parent, [])
+                       if kinds is None or ITEMS[i]["Type"] in kinds]
+
+            if query.get("SortBy", [""])[0] == "Random":
+                import random
+                ids = list(ids)
+                random.shuffle(ids)
+            return self._send(self._query_result(ids, query))
+
+        return self._send({"Error": "not found: " + path}, status=404)
+
+    def do_POST(self):
+        url = urlparse(self.path)
+        path = url.path
+
+        if path == "/QuickConnect/Initiate":
+            secret = "mock-secret-%d" % len(QUICK_CONNECT)
+            QUICK_CONNECT[secret] = {"Authenticated": False, "Secret": secret,
+                                     "Code": "123456", "Polls": 0}
+            return self._send(QUICK_CONNECT[secret])
+
+        if path == "/Users/AuthenticateWithQuickConnect":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length) or b"{}")
+            state = QUICK_CONNECT.get(body.get("Secret", ""))
+            if not state or not state["Authenticated"]:
+                return self._send({"Error": "not authorized"}, status=401)
+            VALID_TOKENS.add("mock-access-token")
+            return self._send({"AccessToken": "mock-access-token",
+                               "ServerId": "mockserver",
+                               "User": {"Id": USER_ID, "Name": USER_NAME}})
+
+        # Playback reporting / user data writes — accepted and ignored.
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            self.rfile.read(length)
+        return self._send({}, status=204)
+
+
+QUICK_CONNECT = {}
+
+# Credentials the mock accepts: the API key a jellyfin.conf might carry, plus
+# any access token handed out by Quick Connect.
+VALID_TOKENS = {"mock-api-key"}
+
+
+if __name__ == "__main__":
+    port = 8096
+    for arg in sys.argv[1:]:
+        if arg.isdigit():
+            port = int(arg)
+    print(f"mock jellyfin on http://127.0.0.1:{port}  "
+          f"({N_MOVIES} movies, {N_SERIES} series, {N_ARTISTS} artists)")
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()

--- a/tools/run-local.sh
+++ b/tools/run-local.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Runs MiSTerFin on a desktop Linux box instead of on the MiSTer, so UI work
+# doesn't need a flash-and-look cycle for every change.
+#
+# There's no /dev/fb0 to draw into here, so the app is pointed at a plain
+# malloc'd buffer of the same size (MISTERFIN_FB, see fb.c) and reads its
+# input from the terminal instead of /dev/input/eventN (MISTERFIN_STDIN /
+# MISTERFIN_KEYS, see main.c). Every fb_flip dumps the visible buffer to a
+# raw file, which tools/raw_to_png.py turns into a viewable PNG using only
+# the Python stdlib.
+#
+# Needs a ./jellyfin.conf pointing at a real server (gitignored) — the same
+# file --preview-browse already expects. Video playback is NOT usable here:
+# mplayer writes straight into a real framebuffer, which a malloc'd buffer
+# can't stand in for.
+#
+# Usage:
+#   tools/run-local.sh                              interactive (arrows, Enter, Esc, Tab, q to quit)
+#   tools/run-local.sh -k "right,right,a"           scripted, screenshot the result
+#   tools/run-local.sh -k "down:200,down:200" -o shot.png
+#   tools/run-local.sh --ntsc -k "a"                240-line NTSC geometry instead of PAL's 288
+#
+# Key names for -k: up down left right a b select start l r wait
+# Each may carry a ":<ms>" delay, e.g. "a:1500" to wait 1.5s after pressing A.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+WIDTH=640
+HEIGHT=288
+KEYS=""
+OUT="/tmp/misterfin_shot.png"
+HOLD=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ntsc)        HEIGHT=240 ;;
+        --pal)         HEIGHT=288 ;;
+        -k|--keys)     KEYS="$2"; shift ;;
+        -o|--out)      OUT="$2"; shift ;;
+        --hold)        HOLD=1 ;;
+        -h|--help)     sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)             echo "unknown option: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+RAW="/tmp/misterfin_frame.raw"
+
+make --no-print-directory
+
+export MISTERFIN_FB="${WIDTH}x${HEIGHT}"
+export MISTERFIN_FRAME_OUT="$RAW"
+
+if [ -n "$KEYS" ]; then
+    export MISTERFIN_KEYS="$KEYS"
+    [ -n "$HOLD" ] && export MISTERFIN_KEYS_HOLD=1
+else
+    export MISTERFIN_STDIN=1
+fi
+
+rm -f "$RAW"
+./misterfin || true
+
+if [ ! -f "$RAW" ]; then
+    echo "no frame was rendered (did startup fail? check jellyfin.conf)" >&2
+    exit 1
+fi
+
+python3 tools/raw_to_png.py "$RAW" "$WIDTH" "$HEIGHT" "$OUT"
+echo "$OUT"

--- a/tools/test-autorepeat.py
+++ b/tools/test-autorepeat.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Drives MiSTerFin with a synthetic gamepad to test held-direction auto-repeat.
+
+Auto-repeat is the one input behaviour the headless harness can't reach on
+its own: it's driven by evdev press/release pairs from a real device, not by
+the terminal (which does its own key repeat) or by scripted key playback
+(which only ever emits discrete presses). So this creates a virtual pad via
+/dev/uinput, holds a direction down for real, and reports how far the cursor
+actually travelled.
+
+Needs write access to /dev/uinput (group `input` on most distros, or run
+under sudo). Stdlib only — the uinput ioctls are issued directly via ctypes.
+
+Usage:
+    python3 tools/mock-jellyfin.py 18096 &      # or point at any server
+    python3 tools/test-autorepeat.py
+"""
+
+import ctypes
+import fcntl
+import os
+import struct
+import subprocess
+import sys
+import time
+
+# ── uinput / evdev constants (linux/input-event-codes.h, linux/uinput.h) ────
+EV_SYN, EV_KEY, EV_ABS = 0x00, 0x01, 0x03
+SYN_REPORT = 0
+BTN_SOUTH, BTN_EAST = 0x130, 0x131
+BTN_TL, BTN_TR = 0x136, 0x137
+BTN_SELECT, BTN_START = 0x13a, 0x13b
+ABS_HAT0X, ABS_HAT0Y = 0x10, 0x11
+ABS_CNT = 64
+
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+UI_SET_ABSBIT = 0x40045567
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+
+BUTTONS = [BTN_SOUTH, BTN_EAST, BTN_TL, BTN_TR, BTN_SELECT, BTN_START]
+
+
+class VirtualPad:
+    """A uinput gamepad with a hat-switch D-pad — the same shape the client's
+    EV_ABS handling expects from a real pad."""
+
+    def __init__(self, name=b"MiSTerFin Test Pad"):
+        self.fd = os.open("/dev/uinput", os.O_WRONLY | os.O_NONBLOCK)
+
+        fcntl.ioctl(self.fd, UI_SET_EVBIT, EV_KEY)
+        fcntl.ioctl(self.fd, UI_SET_EVBIT, EV_ABS)
+        fcntl.ioctl(self.fd, UI_SET_EVBIT, EV_SYN)
+        for btn in BUTTONS:
+            fcntl.ioctl(self.fd, UI_SET_KEYBIT, btn)
+        for axis in (ABS_HAT0X, ABS_HAT0Y):
+            fcntl.ioctl(self.fd, UI_SET_ABSBIT, axis)
+
+        # struct uinput_user_dev: name[80], input_id{4 u16}, u32 ff_effects_max,
+        # then absmax/absmin/absfuzz/absflat, each s32[ABS_CNT].
+        absmax = [0] * ABS_CNT
+        absmin = [0] * ABS_CNT
+        absmax[ABS_HAT0X] = absmax[ABS_HAT0Y] = 1
+        absmin[ABS_HAT0X] = absmin[ABS_HAT0Y] = -1
+        payload = (name.ljust(80, b"\0") +
+                   struct.pack("HHHH", 3, 0x1234, 0x5678, 1) +
+                   struct.pack("I", 0) +
+                   struct.pack("%di" % ABS_CNT, *absmax) +
+                   struct.pack("%di" % ABS_CNT, *absmin) +
+                   struct.pack("%di" % ABS_CNT, *([0] * ABS_CNT)) +
+                   struct.pack("%di" % ABS_CNT, *([0] * ABS_CNT)))
+        os.write(self.fd, payload)
+        fcntl.ioctl(self.fd, UI_DEV_CREATE)
+        time.sleep(0.5)   # let udev create the /dev/input/eventN node
+
+    def _emit(self, ev_type, code, value):
+        # struct input_event: struct timeval{long,long}, u16 type, u16 code, s32 value
+        os.write(self.fd, struct.pack("llHHi", 0, 0, ev_type, code, value))
+
+    def _sync(self):
+        self._emit(EV_SYN, SYN_REPORT, 0)
+
+    def tap(self, code, hold=0.05):
+        self._emit(EV_KEY, code, 1)
+        self._sync()
+        time.sleep(hold)
+        self._emit(EV_KEY, code, 0)
+        self._sync()
+        time.sleep(0.1)
+
+    def hold_hat(self, axis, value, seconds):
+        """Press a D-pad direction, keep it down for `seconds`, then centre."""
+        self.hat_down(axis, value)
+        time.sleep(seconds)
+        self.hat_up(axis)
+        time.sleep(0.2)
+
+    def hat_down(self, axis, value):
+        self._emit(EV_ABS, axis, value)
+        self._sync()
+
+    def hat_up(self, axis):
+        self._emit(EV_ABS, axis, 0)
+        self._sync()
+
+    def close(self):
+        try:
+            fcntl.ioctl(self.fd, UI_DEV_DESTROY)
+        finally:
+            os.close(self.fd)
+
+
+def snapshot(raw_path, out_png, width, height):
+    tmp = raw_path + ".snap"
+    with open(raw_path, "rb") as src, open(tmp, "wb") as dst:
+        dst.write(src.read())
+    subprocess.run([sys.executable, "tools/raw_to_png.py", tmp,
+                    str(width), str(height), out_png], check=True)
+    os.unlink(tmp)
+    return out_png
+
+
+def main():
+    width, height = 640, 288
+    raw = "/tmp/misterfin_frame.raw"
+    out_dir = sys.argv[1] if len(sys.argv) > 1 else "/tmp"
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(root)
+    subprocess.run(["make", "--no-print-directory"], check=True)
+
+    env = dict(os.environ,
+               MISTERFIN_FB=f"{width}x{height}",
+               MISTERFIN_FRAME_OUT=raw)
+    # No MISTERFIN_STDIN / MISTERFIN_KEYS: this test drives the real evdev
+    # path exclusively, which is the entire point.
+    if os.path.exists(raw):
+        os.unlink(raw)
+
+    app = subprocess.Popen(["./misterfin"], env=env,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    pad = VirtualPad()
+    results = {}
+    try:
+        time.sleep(4.0)                       # startup fetch + first draw
+
+        # A completed press anywhere teaches the client this device reports
+        # releases, which is what unlocks auto-repeat (see input_seen_release).
+        # It also drills into the first library, giving us a long list.
+        pad.tap(BTN_EAST)
+        time.sleep(2.5)
+        snapshot(raw, os.path.join(out_dir, "repeat_before.png"), width, height)
+
+        # A single tap should move exactly one row — repeat must not kick in
+        # for a quick press.
+        pad.hold_hat(ABS_HAT0Y, 1, 0.05)
+        time.sleep(0.5)
+        snapshot(raw, os.path.join(out_dir, "repeat_tap.png"), width, height)
+
+        # Now hold it down for real.
+        pad.hold_hat(ABS_HAT0Y, 1, 2.0)
+        time.sleep(0.5)
+        snapshot(raw, os.path.join(out_dir, "repeat_hold.png"), width, height)
+
+        # And confirm it actually STOPS on release rather than running away.
+        time.sleep(1.5)
+        snapshot(raw, os.path.join(out_dir, "repeat_after_release.png"), width, height)
+
+        # Regression case: hold a direction ACROSS screen changes and back.
+        # The app drains pending input on every transition, so a release
+        # arriving afterwards has no matching press left to cancel it — which
+        # is exactly how repeat got stuck on permanently. The round trip ends
+        # back on the list, where DOWN genuinely scrolls, so a stuck repeat
+        # would be plainly visible as a moved cursor.
+        snapshot(raw, os.path.join(out_dir, "screen_00_before.png"), width, height)
+        pad.hat_down(ABS_HAT0Y, 1)            # hold DOWN, and keep holding
+        time.sleep(0.15)                      # a press, but not long enough to repeat
+        pad.tap(BTN_EAST)                     # into the info screen (drains input)
+        time.sleep(2.0)
+        pad.tap(BTN_SOUTH)                    # back to the list (drains again)
+        time.sleep(2.0)                       # STILL holding: must not scroll
+        snapshot(raw, os.path.join(out_dir, "screen_01_held.png"), width, height)
+        pad.hat_up(ABS_HAT0Y)                 # release at last
+        time.sleep(1.5)
+        snapshot(raw, os.path.join(out_dir, "screen_02_released.png"), width, height)
+        results["ok"] = True
+    finally:
+        pad.close()
+        app.terminate()
+        try:
+            app.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            app.kill()
+
+    print("wrote repeat_before/tap/hold/after_release .png to", out_dir)
+    print("expected: tap moves 1 row; 2s hold moves many; after-release count "
+          "is unchanged from hold")
+    return 0 if results.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This is a work in progress, there may be bits of it that are immediately useful but this is verbatim Claude output. Feel free to take pieces and parts from it and discard what you don't want. It also adds a test harness so Claude can test drive the software locally without a deploy.

Changes:

- Quick Connect (vs needing dashboard API key)
- Up Next & Continue Watching support
- Library size is not limited anymore to ~200 items
- Left/right keys skip by page and autorepeat works (avoids RSI scrolling through library)
- Proper json parsing instead of relying on jellyfin json ordering
- Ability to also switch audio tracks instead of just subtitle tracks
- Fixed subtitle naming so it shows display title, not just language
- Fixed subtitle display to strip ASS subtitle markup instead of displaying it verbatim
- Make transcode rates configurable

One thing I am also working on is getting interlaced output video working, however that will require a custom *.rbf core with the patched [ASCAL scaler](https://github.com/iwalton3/ao486_MiSTer/blob/master/sys/ascal.vhd) in order to output interlaced video from the framebuffer.

This branch is tested and known to work on my own MiSTer FPGA.