### PR TITLE
Fix movie, music, and Music Videos library retrieval timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ test:
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_config \
 		tests/test_config.c src/jellyfin.c src/json.c
 	@mkdir -p /tmp/misterfin_test_cfgdir && cd /tmp/misterfin_test_cfgdir && /tmp/misterfin_test_config
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_jellyfin_queries \
+		tests/test_jellyfin_queries.c src/jellyfin.c src/json.c
+	@/tmp/misterfin_test_jellyfin_queries
 
 # -lm: stb_image needs pow(), the Toasty sprite paths need sinf/sincosf. The
 # ARM build gets libm folded into libc by zig's target libc, so only the host

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -284,6 +284,7 @@ static void parse_item_fields(const JsonDoc *doc, const JsonNode *item, JfItem *
     else if (!strcmp(type_buf, "Season"))        it->type = JF_TYPE_SEASON;
     else if (!strcmp(type_buf, "Episode"))       it->type = JF_TYPE_EPISODE;
     else if (!strcmp(type_buf, "Movie"))         it->type = JF_TYPE_MOVIE;
+    else if (!strcmp(type_buf, "MusicVideo"))    it->type = JF_TYPE_MUSIC_VIDEO;
     else if (!strcmp(type_buf, "MusicArtist"))   it->type = JF_TYPE_ARTIST;
     else if (!strcmp(type_buf, "MusicAlbum"))    it->type = JF_TYPE_ALBUM;
     else if (!strcmp(type_buf, "Audio"))         it->type = JF_TYPE_TRACK;
@@ -1265,6 +1266,17 @@ void jf_build_items_path(const JfConfig *cfg, const char *parent_id,
             "&EnableUserData=true"
             "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
             cfg->user_id, safe_parent, start_index, max);
+    /* Music-video libraries use the same flat browsing model as movies.
+     * Search recursively and filter to MusicVideo so intermediate folders do
+     * not appear. Rows display year and runtime, but neither count field. */
+    else if (collection_type && !strcmp(collection_type, "musicvideos"))
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s&Recursive=true&IncludeItemTypes=MusicVideo"
+            "&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks"
+            "&EnableUserData=true"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
     /* Music keeps MiSTerFin's artist -> album -> track hierarchy, so list
      * direct children instead of flattening the library recursively. Keep
      * ChildCount for the album/track totals shown on artist and album rows.
@@ -1861,8 +1873,9 @@ int view_is_synthetic(const JfItem *v) { return v->synthetic != 0; }
 
 const char *collection_item_type(const char *collection_type)
 {
-    if (!strcmp(collection_type, "movies"))  return "Movie";
-    if (!strcmp(collection_type, "tvshows")) return "Series";
-    if (!strcmp(collection_type, "music"))   return "MusicAlbum";
+    if (!strcmp(collection_type, "movies"))      return "Movie";
+    if (!strcmp(collection_type, "tvshows"))     return "Series";
+    if (!strcmp(collection_type, "music"))       return "MusicAlbum";
+    if (!strcmp(collection_type, "musicvideos")) return "MusicVideo";
     return NULL;
 }

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -1240,31 +1240,64 @@ static void parse_total_count(const JsonDoc *doc, int64_t *total_out)
     if (n && n->type == JSON_NUMBER) *total_out = n->i64;
 }
 
-int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
-                   JfItem *out, int max, int64_t *total_out)
+/* Builds the paginated item-list path for a library or folder, selecting the
+ * fields and traversal rules appropriate to its collection type. Overview is
+ * deliberately omitted because browse rows never display it. The info screen
+ * fetches it separately through jf_get_item_details(). */
+void jf_build_items_path(const JfConfig *cfg, const char *parent_id,
+                         const char *collection_type, int start_index, int max,
+                         char *path, size_t path_size)
 {
     char safe_parent[JF_ID_LEN];
     jf_sanitize_id(parent_id, safe_parent, sizeof(safe_parent));
     if (start_index < 0) start_index = 0;
 
-    /* ChildCount here (unlike on a top-level library view — see
-     * jf_count_items's comment) is exactly what it sounds like for a
-     * MusicAlbum: its own track count, confirmed against a real server. */
-    /* Overview is deliberately NOT requested here even though JfItem has a
-     * field for it: no browse-list row ever displays it (the info screen
-     * re-fetches via jf_get_item_details, which is where overview actually
-     * comes from), so it would be several times the JSON per row for nothing.
-     * Response size no longer risks losing data the way it once did — buffers
-     * grow to fit and a short read is now a hard parse failure — but there's
-     * still no reason to transfer and parse a paragraph per row that nothing
-     * reads. */
+    /* Movie libraries can contain intermediate folders, but the browse view
+     * presents a flat movie list. Search recursively and filter to Movie so
+     * folders and other descendants do not appear. Movie rows display year
+     * and runtime, but neither count field, and asking Jellyfin for those
+     * counts can make a large library exceed the request timeout. */
+    if (collection_type && !strcmp(collection_type, "movies"))
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s&Recursive=true&IncludeItemTypes=Movie"
+            "&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks"
+            "&EnableUserData=true"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
+    /* Music keeps MiSTerFin's artist -> album -> track hierarchy, so list
+     * direct children instead of flattening the library recursively. Keep
+     * ChildCount for the album/track totals shown on artist and album rows.
+     * RecursiveItemCount is not displayed for music, and computing it across
+     * a large library can make Jellyfin exceed the request timeout. */
+    else if (collection_type && !strcmp(collection_type, "music"))
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks,ChildCount"
+            "&EnableUserData=true"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
+    /* TV and other collection types keep the standard direct-child query.
+     * Series rows use ChildCount for seasons and RecursiveItemCount for
+     * episodes, both computed in this batched listing instead of separate
+     * requests per series. Unknown collection types retain the established
+     * fields and behavior rather than assuming movie or music semantics. */
+    else
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks,ChildCount,RecursiveItemCount"
+            "&EnableUserData=true"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
+}
+
+int jf_list_items(const JfConfig *cfg, const char *parent_id,
+                   const char *collection_type, int start_index,
+                   JfItem *out, int max, int64_t *total_out)
+{
     char path[512];
-    snprintf(path, sizeof(path),
-        "/Items?userId=%s&ParentId=%s&SortBy=SortName&SortOrder=Ascending"
-        "&Fields=ProductionYear,RunTimeTicks,ChildCount,RecursiveItemCount"
-        "&EnableUserData=true"
-        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=%d&Limit=%d",
-        cfg->user_id, safe_parent, start_index, max);
+    jf_build_items_path(cfg, parent_id, collection_type, start_index, max,
+                        path, sizeof(path));
 
     JfResponse r;
     if (!jf_fetch(cfg, path, &r)) return -1;   /* transport/parse failure, not an empty page */

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -41,6 +41,7 @@ typedef enum {
     JF_TYPE_SEASON,
     JF_TYPE_EPISODE,
     JF_TYPE_MOVIE,
+    JF_TYPE_MUSIC_VIDEO, /* MusicVideo — playable video leaf */
     JF_TYPE_ARTIST,   /* MusicArtist — drills into albums, browsed like JF_TYPE_FOLDER */
     JF_TYPE_ALBUM,    /* MusicAlbum — drills into tracks, browsed like JF_TYPE_FOLDER */
     JF_TYPE_TRACK,    /* Audio — playable leaf, like JF_TYPE_MOVIE but audio-only */
@@ -356,9 +357,10 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max);
 int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *item_type);
 
 /* Items under parent_id (a view, a folder, ...), starting at start_index —
- * one window of a potentially much longer list. Movie libraries are searched
- * recursively and filtered to Movie. Music and other collection types list
- * direct children, with type-specific fields for the counts their rows use.
+ * one window of a potentially much longer list. Movie and music-video
+ * libraries are searched recursively and filtered to their respective item
+ * types. Music and other collection types list direct children, with
+ * type-specific fields for the counts their rows use.
  * Writes the server's untruncated TotalRecordCount to *total_out (may be
  * NULL), which lets the caller distinguish "that's the whole library" from
  * "that's all that fit".

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -355,18 +355,27 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max);
  * root folder has exactly 1 direct child). Returns -1 on failure. */
 int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *item_type);
 
-/* Direct children of parent_id (a view, a folder, ...), starting at
- * start_index — one window of a potentially much longer list. Writes the
- * server's untruncated TotalRecordCount to *total_out (may be NULL), which
- * is what lets the caller know there's more to page to; without it a client
- * cannot tell "that's the whole library" from "that's all that fit".
+/* Items under parent_id (a view, a folder, ...), starting at start_index —
+ * one window of a potentially much longer list. Movie libraries are searched
+ * recursively and filtered to Movie. Music and other collection types list
+ * direct children, with type-specific fields for the counts their rows use.
+ * Writes the server's untruncated TotalRecordCount to *total_out (may be
+ * NULL), which lets the caller distinguish "that's the whole library" from
+ * "that's all that fit".
  *
  * Returns the number of items, or -1 if the request itself failed. That's a
  * distinct value from 0 on purpose: a caller sliding a window has to roll
  * back to the page it already had rather than commit an empty one, and an
  * empty page is a legitimate answer it must not confuse with a dead network. */
-int jf_list_items(const JfConfig *cfg, const char *parent_id, int start_index,
+int jf_list_items(const JfConfig *cfg, const char *parent_id,
+                   const char *collection_type, int start_index,
                    JfItem *out, int max, int64_t *total_out);
+
+/* Builds the request path used by jf_list_items. Exposed so the type-specific
+ * query can be unit-tested without contacting a Jellyfin server. */
+void jf_build_items_path(const JfConfig *cfg, const char *parent_id,
+                         const char *collection_type, int start_index, int max,
+                         char *path, size_t path_size);
 
 /* Same shape as jf_list_items but recursive, and filtered to item_type if
  * non-NULL/non-empty (a BaseItemKind string, e.g. "MusicAlbum"). Used by

--- a/src/main.c
+++ b/src/main.c
@@ -1534,7 +1534,8 @@ static const char *browse_cover_wanted_id(void)
 {
     JfItem *it = (g_item_count > 0) ? &g_items[g_sel] : NULL;
     int wants = it && it->image_tag[0] &&
-        (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_EPISODE ||
+        (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+         it->type == JF_TYPE_EPISODE ||
          it->type == JF_TYPE_SERIES || it->type == JF_TYPE_SEASON ||
          it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM || it->type == JF_TYPE_TRACK);
     return wants ? it->id : "";
@@ -1600,7 +1601,8 @@ static void start_cover_prefetch(void)
     for (int i = 0; i < g_item_count && cp->n < JF_PAGE_SIZE; i++) {
         JfItem *it = &g_items[i];
         int wants = it->image_tag[0] &&
-            (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_EPISODE ||
+            (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+             it->type == JF_TYPE_EPISODE ||
              it->type == JF_TYPE_SERIES || it->type == JF_TYPE_SEASON ||
              it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM || it->type == JF_TYPE_TRACK);
         if (!wants) continue;
@@ -1729,6 +1731,8 @@ static void carousel_format_count(const JfItem *it, int64_t count, char *buf, si
         snprintf(buf, bufsz, "%lld series", (long long)count);
     else if (!strcmp(ct, "music"))
         snprintf(buf, bufsz, "%lld album%s", (long long)count, count == 1 ? "" : "s");
+    else if (!strcmp(ct, "musicvideos"))
+        snprintf(buf, bufsz, "%lld video%s", (long long)count, count == 1 ? "" : "s");
     else
         snprintf(buf, bufsz, "%lld item%s", (long long)count, count == 1 ? "" : "s");
 }
@@ -2004,7 +2008,8 @@ static void draw_browse(FBDev *fb)
 
         char line1[280];
         if (it->year[0] &&
-            (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_SERIES))
+            (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+             it->type == JF_TYPE_SERIES))
             snprintf(line1, sizeof(line1), "%s%s (%s)", type_folder_icon(it->type), it->name, it->year);
         else
             snprintf(line1, sizeof(line1), "%s%s", type_folder_icon(it->type), it->name);
@@ -2013,9 +2018,8 @@ static void draw_browse(FBDev *fb)
         /* Album: year + track count instead of a runtime — there's no
          * single "duration" for a whole album. Track: just its own
          * duration — no watched/resume state, which doesn't make sense for
-         * an individual song the way it does for a movie/episode. Movie/
-         * episode: unchanged runtime + watched/resume, per user request to
-         * leave those as they were. */
+         * an individual song the way it does for a video. Movie, music video,
+         * and episode rows show runtime plus watched/resume state. */
         char line2[64] = {0};
         uint8_t l2r = 0x58, l2g = 0x58, l2b = 0x58;
         if (it->type == JF_TYPE_ALBUM) {
@@ -2047,7 +2051,8 @@ static void draw_browse(FBDev *fb)
             else if (it->child_count > 0)
                 snprintf(line2, sizeof(line2), "%d season%s",
                          it->child_count, it->child_count == 1 ? "" : "s");
-        } else if (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_EPISODE) {
+        } else if (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+                   it->type == JF_TYPE_EPISODE) {
             int minutes = (int)(it->runtime_ticks / 10000000LL / 60);
             if (it->played) {
                 snprintf(line2, sizeof(line2), "%d min - watched", minutes);
@@ -5426,6 +5431,7 @@ int main(int argc, char **argv)
                     break;
                 }
                 case JF_TYPE_MOVIE:
+                case JF_TYPE_MUSIC_VIDEO:
                 case JF_TYPE_EPISODE:
                     info_assets_load(&fb, it, &spinner_frame_ctr);
                     state = STATE_INFO;

--- a/src/main.c
+++ b/src/main.c
@@ -384,6 +384,7 @@ typedef struct {
     FrameKind kind;
     char      title[128];
     char      parent_id[JF_ID_LEN];  /* FRAME_ITEMS */
+    char      collection_type[16];   /* FRAME_ITEMS; inherited through folders */
     char      series_id[JF_ID_LEN];  /* FRAME_SEASONS / FRAME_EPISODES */
     char      season_id[JF_ID_LEN];  /* FRAME_EPISODES */
 } BrowseFrame;
@@ -726,7 +727,7 @@ static int fetch_frame_window(int start_index)
          * RecursiveItemCount, which the server computes for the whole
          * result set in a single batched query. See JfItem's own comment. */
         paginated = 1;
-        g_item_count = jf_list_items(&g_cfg, f->parent_id, start_index,
+        g_item_count = jf_list_items(&g_cfg, f->parent_id, f->collection_type, start_index,
                                       g_items, JF_PAGE_SIZE, &g_total_count);
         break;
     case FRAME_SEASONS:
@@ -791,7 +792,8 @@ static void fetch_frame(void)
 }
 
 static void push_frame(FrameKind kind, const char *title,
-                        const char *parent_id, const char *series_id, const char *season_id)
+                        const char *parent_id, const char *series_id, const char *season_id,
+                        const char *collection_type)
 {
     if (g_stack_depth >= MAX_STACK) return;
     BrowseFrame *f = &g_stack[g_stack_depth++];
@@ -801,6 +803,8 @@ static void push_frame(FrameKind kind, const char *title,
     if (parent_id) strncpy(f->parent_id, parent_id, sizeof(f->parent_id) - 1);
     if (series_id) strncpy(f->series_id, series_id, sizeof(f->series_id) - 1);
     if (season_id) strncpy(f->season_id, season_id, sizeof(f->season_id) - 1);
+    if (collection_type)
+        strncpy(f->collection_type, collection_type, sizeof(f->collection_type) - 1);
     fetch_frame();
 }
 
@@ -4486,7 +4490,7 @@ static int run_preview_browse(int sel, int list_mode)
     grid_init(&g_cfg);
 
     g_root_list_mode = list_mode;
-    push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL);
+    push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL, NULL);
     if (sel >= 0 && sel < g_item_count) g_sel = sel;
 
     draw_browse(&fb);
@@ -4703,7 +4707,7 @@ static int g_startup_result = STARTUP_PENDING;
  * minutes later and from a different thread. */
 static void startup_enter_browse(void)
 {
-    push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL);
+    push_frame(FRAME_VIEWS, "MiSTerFin", NULL, NULL, NULL, NULL);
 }
 
 static void *startup_resolve_thread(void *arg)
@@ -5391,11 +5395,12 @@ int main(int argc, char **argv)
                     /* The two home rows look like folders but have no parent
                      * to list — they're their own kind of frame. */
                     if (view_is_resume(it))
-                        push_frame(FRAME_RESUME, "Continue Watching", NULL, NULL, NULL);
+                        push_frame(FRAME_RESUME, "Continue Watching", NULL, NULL, NULL, NULL);
                     else if (view_is_nextup(it))
-                        push_frame(FRAME_NEXTUP, "Next Up", NULL, NULL, NULL);
+                        push_frame(FRAME_NEXTUP, "Next Up", NULL, NULL, NULL, NULL);
                     else
-                        push_frame(FRAME_ITEMS, it->name, it->id, NULL, NULL);
+                        push_frame(FRAME_ITEMS, it->name, it->id, NULL, NULL,
+                                   it->collection_type[0] ? it->collection_type : f->collection_type);
                     nav = 1;
                     break;
                 case JF_TYPE_ALBUM: {
@@ -5404,19 +5409,19 @@ int main(int argc, char **argv)
                      * so no extra field lookup needed. */
                     char combined[128];
                     snprintf(combined, sizeof(combined), "%s / %s", f->title, it->name);
-                    push_frame(FRAME_ITEMS, combined, it->id, NULL, NULL);
+                    push_frame(FRAME_ITEMS, combined, it->id, NULL, NULL, f->collection_type);
                     nav = 1;
                     break;
                 }
                 case JF_TYPE_SERIES:
-                    push_frame(FRAME_SEASONS, it->name, NULL, it->id, NULL);
+                    push_frame(FRAME_SEASONS, it->name, NULL, it->id, NULL, NULL);
                     nav = 1;
                     break;
                 case JF_TYPE_SEASON: {
                     /* "Series / Season", same pattern as Artist / Album. */
                     char combined[128];
                     snprintf(combined, sizeof(combined), "%s / %s", f->title, it->name);
-                    push_frame(FRAME_EPISODES, combined, NULL, f->series_id, it->id);
+                    push_frame(FRAME_EPISODES, combined, NULL, f->series_id, it->id, NULL);
                     nav = 1;
                     break;
                 }

--- a/tests/test_jellyfin_queries.c
+++ b/tests/test_jellyfin_queries.c
@@ -1,0 +1,113 @@
+/* Unit tests for jf_build_items_path() — build and run with `make test`.
+ *
+ * Item-list queries differ by collection type because Jellyfin can spend
+ * enough time computing unused count fields to exceed MiSTerFin's request
+ * timeout. Compare complete paths so changes to traversal, fields, sorting,
+ * paging, user data, or image selection cannot pass unnoticed. */
+
+#include <stdio.h>
+#include <string.h>
+#include "jellyfin.h"
+
+static int failures;
+static int checks;
+
+#define CHECK_PATH(label, got, expected) do {                         \
+    checks++;                                                         \
+    if (strcmp((got), (expected)) != 0) {                             \
+        failures++;                                                   \
+        printf("  FAIL %s\n    expected: %s\n    got:      %s\n",    \
+               (label), (expected), (got));                           \
+    }                                                                 \
+} while (0)
+
+static JfConfig config(void)
+{
+    JfConfig cfg = {0};
+    strcpy(cfg.user_id, "user-id");
+    return cfg;
+}
+
+static void test_movie_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "movie-view", "movies", 12, 34,
+                        path, sizeof(path));
+
+    CHECK_PATH("movie query", path,
+        "/Items?userId=user-id&ParentId=movie-view"
+        "&Recursive=true&IncludeItemTypes=Movie"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=12&Limit=34");
+}
+
+static void test_music_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "music-view", "music", 5, 64,
+                        path, sizeof(path));
+
+    CHECK_PATH("music query", path,
+        "/Items?userId=user-id&ParentId=music-view"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks,ChildCount"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=5&Limit=64");
+}
+
+static void test_standard_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+    static const char expected[] =
+        "/Items?userId=user-id&ParentId=tv-view"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks,ChildCount,RecursiveItemCount"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=0&Limit=128";
+
+    jf_build_items_path(&cfg, "tv-view", "tvshows", 0, 128,
+                        path, sizeof(path));
+    CHECK_PATH("TV uses standard query", path, expected);
+
+    jf_build_items_path(&cfg, "tv-view", "books", 0, 128,
+                        path, sizeof(path));
+    CHECK_PATH("unknown type uses standard query", path, expected);
+
+    jf_build_items_path(&cfg, "tv-view", NULL, 0, 128,
+                        path, sizeof(path));
+    CHECK_PATH("missing type uses standard query", path, expected);
+}
+
+static void test_input_normalization(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "bad/id?", "music", -7, 9,
+                        path, sizeof(path));
+
+    CHECK_PATH("parent ID and start index are normalized", path,
+        "/Items?userId=user-id&ParentId=bad_id_"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks,ChildCount"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=0&Limit=9");
+}
+
+int main(void)
+{
+    test_movie_query();
+    test_music_query();
+    test_standard_query();
+    test_input_normalization();
+
+    printf("jellyfin queries: %d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/tests/test_jellyfin_queries.c
+++ b/tests/test_jellyfin_queries.c
@@ -61,6 +61,23 @@ static void test_music_query(void)
         "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=5&Limit=64");
 }
 
+static void test_music_video_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "music-video-view", "musicvideos", 7, 50,
+                        path, sizeof(path));
+
+    CHECK_PATH("music-video query", path,
+        "/Items?userId=user-id&ParentId=music-video-view"
+        "&Recursive=true&IncludeItemTypes=MusicVideo"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks"
+        "&EnableUserData=true"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=7&Limit=50");
+}
+
 static void test_standard_query(void)
 {
     JfConfig cfg = config();
@@ -101,12 +118,26 @@ static void test_input_normalization(void)
         "&ImageTypeLimit=1&EnableImageTypes=Primary&StartIndex=0&Limit=9");
 }
 
+static void test_collection_item_types(void)
+{
+    CHECK_PATH("movie collection item type",
+               collection_item_type("movies"), "Movie");
+    CHECK_PATH("TV collection item type",
+               collection_item_type("tvshows"), "Series");
+    CHECK_PATH("music collection item type",
+               collection_item_type("music"), "MusicAlbum");
+    CHECK_PATH("music-video collection item type",
+               collection_item_type("musicvideos"), "MusicVideo");
+}
+
 int main(void)
 {
     test_movie_query();
     test_music_query();
+    test_music_video_query();
     test_standard_query();
     test_input_normalization();
+    test_collection_item_types();
 
     printf("jellyfin queries: %d checks, %d failures\n", checks, failures);
     return failures ? 1 : 0;


### PR DESCRIPTION
## Overview

Large movie and music libraries could exceed MiSTerFin’s fixed 8-second request timeout when opening them. The `/Items` request asked Jellyfin to calculate `ChildCount` and `RecursiveItemCount` for every collection type, even when MiSTerFin did not display those values.

Movie libraries also need recursive traversal because they can contain intermediate folders. Using the standard direct-child query could return folders instead of the flat movie list expected by MiSTerFin.

Music Videos libraries exhibited the same timeout and traversal problems as movie libraries.

## Changes

- Preserve a root library’s `collection_type` in its `BrowseFrame` and pass it through nested folders.
- Build the `/Items` query based on the collection type.
- Query movie libraries recursively with `IncludeItemTypes=Movie`.
- Query Music Videos libraries recursively with `IncludeItemTypes=MusicVideo`.
- Request only `ProductionYear` and `RunTimeTicks` for movie and Music Videos rows.
- Keep music browsing hierarchical while omitting the unused and expensive `RecursiveItemCount` field.
- Preserve the existing TV query, including `ChildCount` and `RecursiveItemCount`.
- Add `MusicVideo` as a playable item type with artwork, year, runtime, watched status, resume status, and video details support.
- Add focused tests that compare complete query paths and verify collection-type mappings.

## Testing

- `make`
- `make test`
- Real-server testing against Jellyfin 10.11.11
- Verified movie, music, TV, and Music Videos libraries open successfully.
- Verified a Music Videos library that previously timed out now returns a flat list of playable videos.
- Observed `/Items` requests completing in under 600 ms during the final regression test, well below the existing 8-second timeout.