### PR TITLE
Add an interactive Ghostty development harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ jellyfin.conf
 token.conf
 device.conf
 crash.log
+debug.log
 __pycache__/
 *.pyc
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test:
 	@/tmp/misterfin_test_hero
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_cache_sweep tests/test_cache_sweep.c src/util.c
 	@/tmp/misterfin_test_cache_sweep
+	python3 -m unittest tools/ghostty/test_ghostty_harness.py
 
 # -lm: stb_image needs pow(), the Toasty sprite paths need sinf/sincosf. The
 # ARM build gets libm folded into libc by zig's target libc, so only the host

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ tools/run-local.sh -k "down:200,a:1500" -o shot.png
 tools/run-local.sh --ntsc -k "a"              # 240-line NTSC geometry instead of PAL's 288
 ```
 
+Ghostty can display the framebuffer as a smooth, interactive 4:3 image through its Kitty graphics support. The helper builds the host binary, passes keyboard input directly to MiSTerFin and writes program output to `/tmp/misterfin-ghostty.log` so it cannot corrupt the image:
+
+```bash
+python3 tools/ghostty/ghostty_harness.py          # PAL
+python3 tools/ghostty/ghostty_harness.py --ntsc   # NTSC
+```
+
+See [`tools/ghostty/README.md`](tools/ghostty/README.md) for controls and additional options.
+
 It needs a `./jellyfin.conf` in the repo root pointing at a real server (gitignored, same file `--preview-browse` expects). **Video playback is not usable this way** — mplayer writes straight into a real framebuffer, which a malloc'd buffer can't stand in for; everything else (browsing, info screens, music metadata, menus, auth) works normally.
 
 `MISTERFIN_INPUT_DEBUG=1` works on real hardware too, not just on a desktop: it prints every incoming input event with its device, raw code and what it mapped to (or why it was dropped) to stderr, so run it over SSH rather than from the Scripts menu. MiSTer's input routing is genuinely unusual — it grabs directly-wired USB pads exclusively and re-emits them on a synthetic "MiSTer virtual input" device — so if a button isn't doing anything, this says whether it's arriving at all and under which code.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ It needs a `./jellyfin.conf` in the repo root pointing at a real server (gitigno
 
 `MISTERFIN_INPUT_DEBUG=1` works on real hardware too, not just on a desktop: it prints every incoming input event with its device, raw code and what it mapped to (or why it was dropped) to stderr, so run it over SSH rather than from the Scripts menu. MiSTer's input routing is genuinely unusual — it grabs directly-wired USB pads exclusively and re-emits them on a synthetic "MiSTer virtual input" device — so if a button isn't doing anything, this says whether it's arriving at all and under which code.
 
-The underlying switches are plain environment variables if you'd rather drive them yourself: `MISTERFIN_FB=640x288` picks the headless buffer size, `MISTERFIN_FRAME_OUT=<path>` dumps each frame, `MISTERFIN_STDIN=1` reads the terminal, and `MISTERFIN_KEYS="right,a:800"` plays a scripted sequence (`MISTERFIN_KEYS_HOLD=1` to stay running afterwards instead of quitting).
+The underlying switches are plain environment variables if you'd rather drive them yourself: `MISTERFIN_FB=640x288` picks the headless buffer size, `MISTERFIN_FRAME_OUT=<path>` dumps each frame, `MISTERFIN_CACHE_ROOT=<path>` selects the persistent artwork cache, `MISTERFIN_STDIN=1` reads the terminal, and `MISTERFIN_KEYS="right,a:800"` plays a scripted sequence (`MISTERFIN_KEYS_HOLD=1` to stay running afterwards instead of quitting).
 
 ---
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -116,7 +116,7 @@ static void grid_cell_order_shuffle(GridLibCache *gc)
 
 /* Turns a Jellyfin GUID view_id into a safe filename — GUIDs are already
  * hex+dashes so this is just a defensive fallback, not real sanitizing. */
-static void grid_cache_disk_path(const char *view_id, int cell_w, char *out, size_t outsz)
+static int grid_cache_disk_path(const char *view_id, int cell_w, char *out, size_t outsz)
 {
     char safe[JF_ID_LEN];
     size_t j = 0;
@@ -129,8 +129,11 @@ static void grid_cache_disk_path(const char *view_id, int cell_w, char *out, siz
      * whatever width the mosaic asked for, and the staleness check below only
      * compares item counts — so without this, changing the fetch width (or
      * simply switching to a display mode with a different cell size) would go
-     * on serving the old resolution off the card forever. */
-    snprintf(out, outsz, GRID_CACHE_DIR "/%s_w%d.dat", safe, cell_w);
+     * on serving the old cached resolution forever. */
+    char dir[256];
+    if (!cache_dir_path("gridcache", dir, sizeof(dir))) return 0;
+    int n = snprintf(out, outsz, "%s/%s_w%d.dat", dir, safe, cell_w);
+    return n >= 0 && (size_t)n < outsz;
 }
 
 /* Persisted grid cache survives an app restart — without it, every
@@ -143,15 +146,15 @@ static void grid_cache_disk_path(const char *view_id, int cell_w, char *out, siz
  * that's a rare edge case for what's purely decorative background art.
  * Pixels are stored raw/uncompressed rather than re-encoded to JPEG (this
  * build's stb_image.h is decode-only, no encoder) — at most ~480KB per
- * library (12 covers * ~100x100x4 bytes), trivial for an SD card. */
+ * library (12 covers * ~100x100x4 bytes), trivial for persistent storage. */
 static int grid_cache_load_from_disk(GridLibCache *gc, const JfItem *view,
                                     const char *item_type, int cell_w)
 {
     int64_t current_count = jf_count_items(s_cfg, view->id, item_type);
     if (current_count < 0) return 0;
 
-    char path[300];
-    grid_cache_disk_path(view->id, cell_w, path, sizeof(path));
+    char path[384];
+    if (!grid_cache_disk_path(view->id, cell_w, path, sizeof(path))) return 0;
     FILE *f = fopen(path, "rb");
     if (!f) return 0;
 
@@ -199,9 +202,10 @@ static void grid_cache_save_to_disk(const GridLibCache *gc, const char *view_id,
                                    int64_t count, int cell_w)
 {
     if (gc->count <= 0) return;
-    mkdir(GRID_CACHE_DIR, 0755);   /* ignore EEXIST/already-there */
-    char path[300];
-    grid_cache_disk_path(view_id, cell_w, path, sizeof(path));
+    char dir[256];
+    if (!cache_dir_ensure("gridcache", dir, sizeof(dir))) return;
+    char path[384];
+    if (!grid_cache_disk_path(view_id, cell_w, path, sizeof(path))) return;
     FILE *f = fopen(path, "wb");
     if (!f) return;
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -5,20 +5,15 @@
 #include "jellyfin.h"
 
 /* The home carousel's dimmed cover-art mosaic background: per-library cover
- * caches (RAM for the session, SD card across launches), a silent background
- * prefetch of every library, and the slow direction-alternating crawl it's
- * drawn with. Owns all of its own state — the only thing it needs from the
- * app is the server config, handed over once via grid_init(). */
+ * caches (RAM for the session, persistent storage across launches), a silent
+ * background prefetch of every library, and the slow direction-alternating
+ * crawl it's drawn with. Owns all of its own state — the only thing it needs
+ * from the app is the server config, handed over once via grid_init(). */
 
 /* Stores the config pointer every later download/count call uses. Call once
  * at startup, before anything else here — the pointed-to config must outlive
  * the app (it's main.c's global). */
 void grid_init(const JfConfig *cfg);
-
-/* Where the persisted mosaic caches live. In the header rather than grid.c
- * because startup also sweeps it for entries under a superseded filename key
- * (see cache_sweep_superseded). */
-#define GRID_CACHE_DIR "/media/fat/misterfin/gridcache"
 
 /* Makes `view`'s mosaic the active one, populating its cache slot first if
  * this is the first visit (blocking: disk cache, else network fetch with a

--- a/src/input.c
+++ b/src/input.c
@@ -266,11 +266,16 @@ static int stdin_key_to_mask(int key)
     case TK_DOWN:               return INP_DOWN;
     case TK_LEFT:               return INP_LEFT;
     case TK_RIGHT:              return INP_RIGHT;
-    /* Same pairing the evdev path uses: Enter/X confirm, Esc/Z back. */
+    /* Match literal A/B keys to the labels drawn on screen. The internal
+     * names follow controller positions: INP_A is screen B (confirm), and
+     * INP_B is screen A (back). Enter/X and Esc/Z retain the established
+     * keyboard and emulator-style alternatives. */
     case '\r': case '\n':
+    case 'b': case 'B':
     case 'x': case 'X':         return INP_A;
     case TK_ESC:
     case 0x7f: case '\b':
+    case 'a': case 'A':
     case 'z': case 'Z':         return INP_B;
     case '\t':                  return INP_SELECT;
     case TK_HOME: case 'p':     return INP_START;
@@ -634,4 +639,3 @@ int input_repeat(void)
     repeat_count++;
     return held;
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -52,16 +52,15 @@
  * GRID_POSTER_TMP) for its own main-thread downloads — same thread, so
  * sharing is deliberate and safe; keep the two in sync. */
 #define POSTER_TMP   "/tmp/misterfin_poster.img"
-/* Per-item browse-list cover art, cached to the SD card (same idea as the
- * home-screen grid cache above) so scrolling a list reads covers from the
- * card instead of re-downloading each one — no network round-trip on the
+/* Per-item browse-list cover art, cached to persistent storage (same idea as
+ * the home-screen grid cache above) so scrolling a list reads covers from the
+ * cache instead of re-downloading each one — no network round-trip on the
  * main thread, so no scroll freeze and no blank-then-appear. A background
  * thread (cover_prefetch_thread) fills the cache for the current list;
  * COVER_TMP_BG is that thread's own download scratch path. */
 /* UI click/confirm clips. Same directory screenshot.c's shutter.wav lives in,
  * and already deployed by the Makefile and copied by the in-app updater. */
 #define SFX_DIR      "/media/fat/misterfin/sfx"
-#define COVER_CACHE_DIR "/media/fat/misterfin/covercache"
 #define COVER_TMP_BG   "/tmp/misterfin_cover_bg.img"
 #define CRASH_LOG    "/media/fat/misterfin/crash.log"
 /* mplayer's -af export writes live PCM samples to this mmap'd file for the
@@ -802,7 +801,7 @@ static void fetch_frame(void)
     }
 
     /* Fill the SD cover cache for this list in the background so scrolling
-     * reads covers off the card, never off the network. */
+     * reads covers from the persistent cache, never from the network. */
     start_cover_prefetch();
 }
 
@@ -1510,14 +1509,14 @@ static uint8_t *g_browse_cover_px = NULL;
 static int      g_browse_cover_w = 0, g_browse_cover_h = 0;
 static char     g_browse_cover_item_id[JF_ID_LEN] = "";
 
-/* Cache-file path for one item's cover on the SD card. Keyed by item id plus
+/* Cache-file path for one item's cover. Keyed by item id plus
  * a few chars of the image tag, so replacing the artwork server-side lands on
  * a new filename rather than serving stale art — and by the width it was
  * fetched at, so changing BROWSE_COVER_DL_W re-fetches instead of serving the
  * old size forever. Without that last part every card already in the wild
  * keeps whatever resolution it first cached, which is a change that silently
  * does nothing for existing users and works only on a fresh install. */
-static void cover_cache_path(const char *item_id, const char *tag, char *out, size_t outsz)
+static int cover_cache_path(const char *item_id, const char *tag, char *out, size_t outsz)
 {
     char safe[JF_ID_LEN + 12];
     size_t j = 0;
@@ -1531,23 +1530,27 @@ static void cover_cache_path(const char *item_id, const char *tag, char *out, si
         safe[j++] = isalnum((unsigned char)c) ? c : '_';
     }
     safe[j] = '\0';
-    snprintf(out, outsz, COVER_CACHE_DIR "/%s_w%d.img", safe, BROWSE_COVER_DL_W);
+    char dir[256];
+    if (!cache_dir_path("covercache", dir, sizeof(dir))) return 0;
+    int n = snprintf(out, outsz, "%s/%s_w%d.img", dir, safe, BROWSE_COVER_DL_W);
+    return n >= 0 && (size_t)n < outsz;
 }
 
-/* Downloads one cover into the SD cache if not already there. Downloads to a
- * ".tmp" sibling IN THE CACHE DIR (so the rename into place stays within one
- * filesystem — a /tmp->/media/fat rename fails with EXDEV) and renames it, so
- * the main thread's browse_cover_load never reads a half-written file. */
+/* Downloads one cover into the persistent cache if not already there.
+ * Downloads to a ".tmp" sibling IN THE CACHE DIR, then renames it so the main
+ * thread never reads a half-written file. Keeping both paths on one filesystem
+ * also avoids the EXDEV failure that a /tmp-to-/media/fat rename would cause. */
 static void cover_fetch_to_cache(const char *image_item_id, const char *tag,
                                   const char *item_id)
 {
     if (!tag[0]) return;
-    char cpath[160];
-    cover_cache_path(item_id, tag, cpath, sizeof(cpath));
+    char cpath[384];
+    if (!cover_cache_path(item_id, tag, cpath, sizeof(cpath))) return;
     struct stat st;
     if (stat(cpath, &st) == 0 && st.st_size > 0) return;   /* already cached */
-    mkdir(COVER_CACHE_DIR, 0755);   /* ensure the dir exists for tmp + final */
-    char tmp[176];
+    char dir[256];
+    if (!cache_dir_ensure("covercache", dir, sizeof(dir))) return;
+    char tmp[400];
     snprintf(tmp, sizeof(tmp), "%s.tmp", cpath);
     if (jf_download_item_image(&g_cfg, image_item_id, "Primary", tag,
                                 BROWSE_COVER_DL_W, tmp)) {
@@ -1569,10 +1572,10 @@ static const char *browse_cover_wanted_id(void)
     return wants ? it->id : "";
 }
 
-/* Loads the selected row's cover into the top-right panel — from the SD cache
- * ONLY, never the network. A cached cover shows instantly (no freeze, no
- * blank); an as-yet-uncached one leaves the panel blank until the background
- * prefetch (cover_prefetch_thread) writes it to the card, at which point the
+/* Loads the selected row's cover into the top-right panel — from the
+ * persistent cache ONLY, never the network. A cached cover shows instantly
+ * with no freeze; an uncached one leaves the panel blank until the background
+ * prefetch (cover_prefetch_thread) writes it to storage, at which point the
  * next browse redraw (~100ms, for the live clock/marquee) picks it up. So the
  * main thread never blocks on a per-item download — that was the scroll
  * freeze — and any list visited before shows every cover instantly. Stale art
@@ -1590,8 +1593,8 @@ static void browse_cover_load(void)
     g_browse_cover_item_id[0] = '\0';
     if (want[0] == '\0') return;   /* this item has no cover */
 
-    char cpath[160];
-    cover_cache_path(it->id, it->image_tag, cpath, sizeof(cpath));
+    char cpath[384];
+    if (!cover_cache_path(it->id, it->image_tag, cpath, sizeof(cpath))) return;
     int w = 0, h = 0;
     uint8_t *px = load_image_keep(cpath, &w, &h);
     if (!px) return;   /* not cached yet — blank; prefetch fills it, next redraw loads it */
@@ -1613,8 +1616,12 @@ static void browse_cover_load(void)
 static void *cache_sweep_thread(void *arg)
 {
     (void)arg;
-    int n  = cache_sweep_superseded(COVER_CACHE_DIR, ".img", "_w");
-    n     += cache_sweep_superseded(GRID_CACHE_DIR,  ".dat", "_w");
+    char cover_dir[256], grid_dir[256];
+    int n = 0;
+    if (cache_dir_path("covercache", cover_dir, sizeof(cover_dir)))
+        n += cache_sweep_superseded(cover_dir, ".img", "_w");
+    if (cache_dir_path("gridcache", grid_dir, sizeof(grid_dir)))
+        n += cache_sweep_superseded(grid_dir, ".dat", "_w");
     /* Only when it did something — on every launch after the first there is
      * nothing to find, and a line saying so each time is noise. */
     if (n > 0) jf_log_line("cache: reclaimed %d entries from a superseded key", n);
@@ -1666,7 +1673,7 @@ static char     g_hero_item_id[JF_ID_LEN] = "";
 /* 'h' prefix so a hero and a cover for the same item can't collide in the one
  * cache directory, plus the fetch width for the same reason cover_cache_path
  * carries it. */
-static void hero_cache_path(const char *item_id, const char *tag, char *out, size_t outsz)
+static int hero_cache_path(const char *item_id, const char *tag, char *out, size_t outsz)
 {
     char safe[JF_ID_LEN + 12];
     size_t j = 0;
@@ -1679,7 +1686,10 @@ static void hero_cache_path(const char *item_id, const char *tag, char *out, siz
         safe[j++] = isalnum((unsigned char)c) ? c : '_';
     }
     safe[j] = '\0';
-    snprintf(out, outsz, COVER_CACHE_DIR "/h%s_w%d.img", safe, HERO_DL_W);
+    char dir[256];
+    if (!cache_dir_path("covercache", dir, sizeof(dir))) return 0;
+    int n = snprintf(out, outsz, "%s/h%s_w%d.img", dir, safe, HERO_DL_W);
+    return n >= 0 && (size_t)n < outsz;
 }
 
 /* Mirror of cover_fetch_to_cache — same tmp-then-rename inside the cache dir
@@ -1687,13 +1697,14 @@ static void hero_cache_path(const char *item_id, const char *tag, char *out, siz
 static void hero_fetch_to_cache(const char *img_id, const char *tag, const char *item_id)
 {
     if (!tag[0] || !img_id[0]) return;
-    char cpath[176];
-    hero_cache_path(item_id, tag, cpath, sizeof(cpath));
+    char cpath[384];
+    if (!hero_cache_path(item_id, tag, cpath, sizeof(cpath))) return;
     if (access(cpath, F_OK) == 0) return;
 
-    char tmp[192];
+    char tmp[400];
     snprintf(tmp, sizeof(tmp), "%s.tmp", cpath);
-    mkdir(COVER_CACHE_DIR, 0755);
+    char dir[256];
+    if (!cache_dir_ensure("covercache", dir, sizeof(dir))) return;
     if (jf_download_item_image(&g_cfg, img_id, "Backdrop/0", tag, HERO_DL_W, tmp)) {
         if (rename(tmp, cpath) != 0) unlink(tmp);
     } else {
@@ -1711,8 +1722,8 @@ static const char *browse_hero_wanted_id(void)
     return (it && it->backdrop_tag[0]) ? it->id : "";
 }
 
-/* Same SD-cache-only rule as browse_cover_load: never a network fetch on the
- * main thread, so scrolling can't freeze. An uncached backdrop simply leaves
+/* Same persistent-cache-only rule as browse_cover_load: never a network fetch
+ * on the main thread, so scrolling can't freeze. An uncached backdrop leaves
  * the background black until the prefetch writes it and the next redraw picks
  * it up. */
 static void browse_hero_load(FBDev *fb)
@@ -1728,8 +1739,8 @@ static void browse_hero_load(FBDev *fb)
     g_hero_item_id[0] = '\0';
     if (want[0] == '\0') return;
 
-    char cpath[176];
-    hero_cache_path(it->id, it->backdrop_tag, cpath, sizeof(cpath));
+    char cpath[384];
+    if (!hero_cache_path(it->id, it->backdrop_tag, cpath, sizeof(cpath))) return;
     int w = 0, h = 0;
     uint8_t *px = load_image_keep(cpath, &w, &h);
     if (!px) return;
@@ -1741,9 +1752,10 @@ static void browse_hero_load(FBDev *fb)
     g_hero_item_id[sizeof(g_hero_item_id) - 1] = '\0';
 }
 
-/* Background fill of the SD cover cache for the current list, so scrolling
- * reads covers off the card. Snapshots the item ids/tags (never touches
- * g_items off-thread) and stops early if the list changed under it (g_cover_gen). */
+/* Background fill of the persistent cover cache for the current list, so
+ * scrolling reads covers without a network request. Snapshots the item
+ * ids/tags (never touches g_items off-thread) and stops early if the list
+ * changed under it (g_cover_gen). */
 typedef struct {
     int gen, n;
     struct { char id[JF_ID_LEN], img_id[JF_ID_LEN], tag[JF_ID_LEN],

--- a/src/util.c
+++ b/src/util.c
@@ -26,9 +26,44 @@ uint8_t *load_image_keep(const char *path, int *w, int *h)
 }
 
 #include <dirent.h>
+#include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+
+#define DEFAULT_CACHE_ROOT "/media/fat/misterfin"
+
+static const char *cache_root(void)
+{
+    const char *root = getenv("MISTERFIN_CACHE_ROOT");
+    return (root && root[0]) ? root : DEFAULT_CACHE_ROOT;
+}
+
+int cache_dir_path(const char *name, char *out, size_t outsz)
+{
+    if (!name || !name[0] || strchr(name, '/') || !out || outsz == 0) return 0;
+    const char *root = cache_root();
+    size_t len = strlen(root);
+    int n = snprintf(out, outsz, "%s%s%s", root,
+                     (len > 0 && root[len - 1] == '/') ? "" : "/", name);
+    return n >= 0 && (size_t)n < outsz;
+}
+
+static int ensure_dir(const char *path)
+{
+    if (mkdir(path, 0755) == 0) return 1;
+    if (errno != EEXIST) return 0;
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+int cache_dir_ensure(const char *name, char *out, size_t outsz)
+{
+    const char *root = cache_root();
+    if (!ensure_dir(root) || !cache_dir_path(name, out, outsz)) return 0;
+    return ensure_dir(out);
+}
 
 int cache_sweep_superseded(const char *dir, const char *ext, const char *keep_substr)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /* Monotonic seconds — the one timebase everything animates and times
@@ -13,9 +14,16 @@ double now_sec(void);
 uint8_t *load_image_tmp(const char *tmp_path, int *w, int *h);
 
 /* Like load_image_tmp but KEEPS the file — for reading a persistent cache
- * file off the SD card (the cover cache), where deleting it would defeat the
- * whole point. */
+ * file, where deleting it would defeat the whole point. */
 uint8_t *load_image_keep(const char *path, int *w, int *h);
+
+/* Builds one cache-directory path beneath MISTERFIN_CACHE_ROOT. The MiSTer
+ * install directory remains the default; the desktop harness overrides the
+ * root so the same artwork cache code works without a /media/fat mount. */
+int cache_dir_path(const char *name, char *out, size_t outsz);
+
+/* Creates the configured cache root and named child directory if needed. */
+int cache_dir_ensure(const char *name, char *out, size_t outsz);
 
 /* Deletes cache entries left behind by a superseded filename key: every
  * regular file directly in `dir` whose name ends in `ext` and does NOT

--- a/tests/test_cache_sweep.c
+++ b/tests/test_cache_sweep.c
@@ -1,5 +1,5 @@
-/* cache_sweep_superseded() — reclaiming cache entries whose filename key was
- * superseded by a change of fetch width.
+/* Cache path selection and cache_sweep_superseded(), which reclaims entries
+ * whose filename key was superseded by a change of fetch width.
  *
  * This is the one piece of code in the app that deletes the user's files, so
  * what it must NOT delete matters more than what it must. Every assertion
@@ -52,6 +52,28 @@ static int checks;
 
 int main(void)
 {
+    char cache_path[256];
+    unsetenv("MISTERFIN_CACHE_ROOT");
+    CHECK(cache_dir_path("covercache", cache_path, sizeof(cache_path)),
+          "default cache path builds");
+    CHECK(!strcmp(cache_path, "/media/fat/misterfin/covercache"),
+          "default remains the MiSTer install path");
+
+    assert(system("rm -rf /tmp/misterfin_test_cache_root") == 0);
+    setenv("MISTERFIN_CACHE_ROOT", "/tmp/misterfin_test_cache_root/", 1);
+    CHECK(cache_dir_path("gridcache", cache_path, sizeof(cache_path)),
+          "overridden cache path builds");
+    CHECK(!strcmp(cache_path, "/tmp/misterfin_test_cache_root/gridcache"),
+          "trailing slash is not duplicated");
+    CHECK(cache_dir_ensure("gridcache", cache_path, sizeof(cache_path)),
+          "override root and child are created");
+    struct stat cache_st;
+    CHECK(stat(cache_path, &cache_st) == 0 && S_ISDIR(cache_st.st_mode),
+          "created cache child is a directory");
+    CHECK(!cache_dir_path("../escape", cache_path, sizeof(cache_path)),
+          "cache child cannot contain a slash");
+    unsetenv("MISTERFIN_CACHE_ROOT");
+
     /* Fresh tree every run. */
     char cmd[600];
     snprintf(cmd, sizeof cmd, "rm -rf %s && mkdir -p %s/sub", DIR_PATH, DIR_PATH);
@@ -105,6 +127,7 @@ int main(void)
 
     snprintf(cmd, sizeof cmd, "rm -rf %s", DIR_PATH);
     (void)system(cmd);
+    assert(system("rm -rf /tmp/misterfin_test_cache_root") == 0);
     printf("cache sweep: %d checks, 0 failures\n", checks);
     return 0;
 }

--- a/tools/ghostty/README.md
+++ b/tools/ghostty/README.md
@@ -23,6 +23,8 @@ Keys match the desktop harness:
 
 The helper writes MiSTerFin's stdout and stderr to `/tmp/misterfin-ghostty.log` so terminal output cannot corrupt the image. Pass `--log PATH` to choose another location.
 
+Artwork is cached under `/tmp/misterfin-cache` by default. Set `MISTERFIN_CACHE_ROOT` before launching the helper to use another location.
+
 Ghostty must report `TERM=xterm-ghostty`. The `--force` option permits another terminal that implements the Kitty graphics protocol.
 
 The viewer double-buffers terminal images to avoid flicker. It uploads a complete frame under an alternate image ID, places the new frame over the current frame, and only then deletes the old frame. MiSTerFin's 640x240 and 640x288 framebuffers use non-square CRT pixels, so the viewer fits them into a physical 4:3 rectangle using the terminal's cell geometry. The viewer caps presentation at 20 FPS by default and skips duplicate frames. Change the cap with `--fps NUMBER`. This cap only affects the terminal preview. It does not change MiSTerFin's own frame loop.

--- a/tools/ghostty/README.md
+++ b/tools/ghostty/README.md
@@ -1,0 +1,36 @@
+# Ghostty interactive harness
+
+This helper presents MiSTerFin's existing desktop framebuffer inside Ghostty. MiSTerFin still reads the terminal directly, so the helper does not translate or intercept input.
+
+From the repository root, run:
+
+```bash
+python3 tools/ghostty/ghostty_harness.py --ntsc
+```
+
+Use `--pal` for the 640x288 layout. PAL is the default. The helper builds the host binary before launch. Pass `--no-build` to use the existing binary.
+
+Keys match the desktop harness:
+
+- Arrow keys navigate.
+- `B`, Enter, or `X` confirms, matching the on-screen B label.
+- `A`, Escape, Backspace, or `Z` goes back, matching the on-screen A label.
+- Tab is Select.
+- Home or `P` is Start.
+- Page Up or `[` is the left shoulder button.
+- Page Down or `]` is the right shoulder button.
+- `Q` exits.
+
+The helper writes MiSTerFin's stdout and stderr to `/tmp/misterfin-ghostty.log` so terminal output cannot corrupt the image. Pass `--log PATH` to choose another location.
+
+Ghostty must report `TERM=xterm-ghostty`. The `--force` option permits another terminal that implements the Kitty graphics protocol.
+
+The viewer double-buffers terminal images to avoid flicker. It uploads a complete frame under an alternate image ID, places the new frame over the current frame, and only then deletes the old frame. MiSTerFin's 640x240 and 640x288 framebuffers use non-square CRT pixels, so the viewer fits them into a physical 4:3 rectangle using the terminal's cell geometry. The viewer caps presentation at 20 FPS by default and skips duplicate frames. Change the cap with `--fps NUMBER`. This cap only affects the terminal preview. It does not change MiSTerFin's own frame loop.
+
+Video playback remains unavailable in the desktop harness because `mplayer` opens `/dev/fb0` directly. Browsing, artwork, menus, setup, and metadata use the headless framebuffer and are visible.
+
+Run the helper tests with:
+
+```bash
+python3 -m unittest tools/ghostty/test_ghostty_harness.py
+```

--- a/tools/ghostty/ghostty_harness.py
+++ b/tools/ghostty/ghostty_harness.py
@@ -231,6 +231,17 @@ def stop_process(process: subprocess.Popen[bytes]) -> None:
         process.wait()
 
 
+def child_environment(width: int, height: int, frame_path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["MISTERFIN_FB"] = f"{width}x{height}"
+    env["MISTERFIN_FRAME_OUT"] = str(frame_path)
+    env["MISTERFIN_STDIN"] = "1"
+    env.setdefault("MISTERFIN_CACHE_ROOT", "/tmp/misterfin-cache")
+    env.pop("MISTERFIN_KEYS", None)
+    env.pop("MISTERFIN_KEYS_HOLD", None)
+    return env
+
+
 def run(args: argparse.Namespace) -> int:
     if "ghostty" not in os.environ.get("TERM", "").lower() and not args.force:
         print("This viewer requires Ghostty (expected TERM=xterm-ghostty).", file=sys.stderr)
@@ -272,12 +283,7 @@ def run(args: argparse.Namespace) -> int:
     try:
         with tempfile.TemporaryDirectory(prefix="misterfin-ghostty-") as temp_dir:
             frame_path = Path(temp_dir) / "frame.raw"
-            env = os.environ.copy()
-            env["MISTERFIN_FB"] = f"{width}x{height}"
-            env["MISTERFIN_FRAME_OUT"] = str(frame_path)
-            env["MISTERFIN_STDIN"] = "1"
-            env.pop("MISTERFIN_KEYS", None)
-            env.pop("MISTERFIN_KEYS_HOLD", None)
+            env = child_environment(width, height, frame_path)
 
             with args.log.open("wb") as log, open("/dev/tty", "wb", buffering=0) as tty:
                 presenter = GhosttyPresenter(tty, width, height)

--- a/tools/ghostty/ghostty_harness.py
+++ b/tools/ghostty/ghostty_harness.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run MiSTerFin's desktop harness as an interactive image in Ghostty."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import os
+from pathlib import Path
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+from typing import BinaryIO, Iterable
+
+
+ESC = b"\x1b"
+ST = ESC + b"\\"
+IMAGE_IDS = (0x4D465001, 0x4D465002)
+PLACEMENT_ID = 1
+DEFAULT_FPS = 20.0
+DISPLAY_ASPECT = 4.0 / 3.0
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def bgrx_to_rgb(frame: bytes, width: int, height: int) -> bytes:
+    """Convert MiSTerFin's little-endian BGRX8888 buffer to packed RGB."""
+    expected = width * height * 4
+    if len(frame) != expected:
+        raise ValueError(f"expected {expected} frame bytes, got {len(frame)}")
+
+    rgb = bytearray(width * height * 3)
+    rgb[0::3] = frame[2::4]
+    rgb[1::3] = frame[1::4]
+    rgb[2::3] = frame[0::4]
+    return bytes(rgb)
+
+
+def kitty_chunks(control: str, payload: bytes = b"") -> Iterable[bytes]:
+    """Encode one Kitty graphics command, splitting large payloads safely."""
+    encoded = base64.b64encode(payload)
+    if not encoded:
+        yield ESC + b"_G" + control.encode("ascii") + b";" + ST
+        return
+
+    chunks = [encoded[i:i + 4096] for i in range(0, len(encoded), 4096)]
+    for index, chunk in enumerate(chunks):
+        more = int(index + 1 < len(chunks))
+        prefix = f"{control},m={more}" if index == 0 else f"m={more}"
+        yield ESC + b"_G" + prefix.encode("ascii") + b";" + chunk + ST
+
+
+def display_cells(
+    columns: int,
+    rows: int,
+    pixel_width: int = 0,
+    pixel_height: int = 0,
+) -> tuple[int, int]:
+    """Fit MiSTerFin's non-square pixels into a physical 4:3 rectangle."""
+    columns = max(columns, 1)
+    rows = max(rows, 1)
+
+    if pixel_width > 0 and pixel_height > 0:
+        cell_width = pixel_width / columns
+        cell_height = pixel_height / rows
+    else:
+        # A typical terminal cell is about twice as tall as it is wide.
+        cell_width = 1.0
+        cell_height = 2.0
+
+    width_at_full_columns = columns * cell_width
+    image_height_pixels = width_at_full_columns / DISPLAY_ASPECT
+    fitted_rows = max(1, round(image_height_pixels / cell_height))
+
+    if fitted_rows <= rows:
+        return columns, fitted_rows
+
+    height_at_full_rows = rows * cell_height
+    image_width_pixels = height_at_full_rows * DISPLAY_ASPECT
+    fitted_columns = max(1, round(image_width_pixels / cell_width))
+    return min(fitted_columns, columns), rows
+
+
+def terminal_geometry(tty: BinaryIO) -> tuple[int, int, int, int]:
+    packed = fcntl.ioctl(tty.fileno(), termios.TIOCGWINSZ, b"\0" * 8)
+    rows, columns, pixel_width, pixel_height = struct.unpack("HHHH", packed)
+    fallback = shutil.get_terminal_size((80, 24))
+    return columns or fallback.columns, rows or fallback.lines, pixel_width, pixel_height
+
+
+def read_complete_frame(path: Path, expected_size: int) -> bytes | None:
+    """Read a frame only if the producer did not change it during the read."""
+    try:
+        with path.open("rb") as source:
+            before = os.fstat(source.fileno())
+            if before.st_size != expected_size:
+                return None
+            frame = source.read()
+            after = os.fstat(source.fileno())
+    except FileNotFoundError:
+        return None
+
+    if len(frame) != expected_size:
+        return None
+    if before.st_size != after.st_size or before.st_mtime_ns != after.st_mtime_ns:
+        return None
+    return frame
+
+
+class GhosttyPresenter:
+    def __init__(self, tty: BinaryIO, width: int, height: int):
+        self.tty = tty
+        self.width = width
+        self.height = height
+        self.image_id: int | None = None
+
+    def write(self, data: bytes) -> None:
+        self.tty.write(data)
+
+    def enter(self) -> None:
+        self.write(b"\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H")
+
+    def leave(self) -> None:
+        self.delete_image()
+        self.write(b"\x1b[?25h\x1b[?1049l")
+
+    def delete_image(self, image_id: int | None = None) -> None:
+        image_id = self.image_id if image_id is None else image_id
+        if image_id is None:
+            return
+        for chunk in kitty_chunks(f"a=d,d=I,i={image_id},q=2"):
+            self.write(chunk)
+        if image_id == self.image_id:
+            self.image_id = None
+
+    def create_image(self, image_id: int, rgb: bytes, columns: int, rows: int) -> None:
+        self.write(b"\x1b[H")
+        control = (
+            f"a=T,f=24,t=d,s={self.width},v={self.height},i={image_id},"
+            f"p={PLACEMENT_ID},c={columns},r={rows},C=1,q=2"
+        )
+        for chunk in kitty_chunks(control, rgb):
+            self.write(chunk)
+        self.image_id = image_id
+
+    def replace_image(self, image_id: int, rgb: bytes, columns: int, rows: int) -> None:
+        # Upload without displaying, place the complete new image over the old
+        # one, then release the old image. There is never a blank placement.
+        control = f"a=t,f=24,t=d,s={self.width},v={self.height},i={image_id},q=2"
+        for chunk in kitty_chunks(control, rgb):
+            self.write(chunk)
+
+        self.write(b"\x1b[H")
+        placement = (
+            f"a=p,i={image_id},p={PLACEMENT_ID},c={columns},r={rows},C=1,q=2"
+        )
+        for chunk in kitty_chunks(placement):
+            self.write(chunk)
+
+        old_image_id = self.image_id
+        self.image_id = image_id
+        self.delete_image(old_image_id)
+
+    def show(self, frame: bytes) -> None:
+        columns, rows, pixel_width, pixel_height = terminal_geometry(self.tty)
+        image_columns, image_rows = display_cells(
+            columns,
+            rows,
+            pixel_width,
+            pixel_height,
+        )
+        rgb = bgrx_to_rgb(frame, self.width, self.height)
+
+        if self.image_id is None:
+            self.create_image(IMAGE_IDS[0], rgb, image_columns, image_rows)
+        else:
+            next_image_id = IMAGE_IDS[1] if self.image_id == IMAGE_IDS[0] else IMAGE_IDS[0]
+            self.replace_image(next_image_id, rgb, image_columns, image_rows)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Navigate MiSTerFin inside Ghostty using the desktop harness."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--ntsc", action="store_true", help="use the 640x240 layout")
+    mode.add_argument("--pal", action="store_true", help="use the 640x288 layout (default)")
+    parser.add_argument(
+        "--fps",
+        type=float,
+        default=DEFAULT_FPS,
+        help=f"maximum terminal presentation rate (default: {DEFAULT_FPS:g})",
+    )
+    parser.add_argument(
+        "--binary",
+        type=Path,
+        default=REPO_ROOT / "misterfin",
+        help="MiSTerFin host binary to run",
+    )
+    parser.add_argument("--no-build", action="store_true", help="do not run make first")
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("/tmp/misterfin-ghostty.log"),
+        help="child stdout and stderr log",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="run even when TERM does not identify Ghostty",
+    )
+    args = parser.parse_args(argv)
+    if args.fps <= 0:
+        parser.error("--fps must be greater than zero")
+    return args
+
+
+def stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def run(args: argparse.Namespace) -> int:
+    if "ghostty" not in os.environ.get("TERM", "").lower() and not args.force:
+        print("This viewer requires Ghostty (expected TERM=xterm-ghostty).", file=sys.stderr)
+        print("Use --force only with another Kitty-graphics-compatible terminal.", file=sys.stderr)
+        return 2
+
+    if not sys.stdin.isatty():
+        print("Interactive MiSTerFin input requires a terminal on stdin.", file=sys.stderr)
+        return 2
+
+    if not args.no_build:
+        completed = subprocess.run(["make", "--no-print-directory"], cwd=REPO_ROOT)
+        if completed.returncode:
+            return completed.returncode
+
+    binary = args.binary.resolve()
+    if not binary.is_file():
+        print(f"MiSTerFin host binary not found: {binary}", file=sys.stderr)
+        return 2
+
+    width = 640
+    height = 240 if args.ntsc else 288
+    frame_size = width * height * 4
+    frame_interval = 1.0 / args.fps
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+
+    process: subprocess.Popen[bytes] | None = None
+    stopping = False
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    previous_handlers = {
+        signum: signal.signal(signum, request_stop)
+        for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+    }
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="misterfin-ghostty-") as temp_dir:
+            frame_path = Path(temp_dir) / "frame.raw"
+            env = os.environ.copy()
+            env["MISTERFIN_FB"] = f"{width}x{height}"
+            env["MISTERFIN_FRAME_OUT"] = str(frame_path)
+            env["MISTERFIN_STDIN"] = "1"
+            env.pop("MISTERFIN_KEYS", None)
+            env.pop("MISTERFIN_KEYS_HOLD", None)
+
+            with args.log.open("wb") as log, open("/dev/tty", "wb", buffering=0) as tty:
+                presenter = GhosttyPresenter(tty, width, height)
+                presenter.enter()
+                try:
+                    process = subprocess.Popen(
+                        [str(binary)],
+                        cwd=REPO_ROOT,
+                        env=env,
+                        stdin=None,
+                        stdout=log,
+                        stderr=log,
+                    )
+                    previous_frame: bytes | None = None
+                    next_frame_at = 0.0
+
+                    while process.poll() is None and not stopping:
+                        now = time.monotonic()
+                        if now < next_frame_at:
+                            time.sleep(min(next_frame_at - now, 0.01))
+                            continue
+
+                        frame = read_complete_frame(frame_path, frame_size)
+                        if frame is not None and frame != previous_frame:
+                            presenter.show(frame)
+                            previous_frame = frame
+                        next_frame_at = time.monotonic() + frame_interval
+                finally:
+                    if process is not None:
+                        stop_process(process)
+                    presenter.leave()
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+    assert process is not None
+    if process.returncode not in (0, -signal.SIGTERM):
+        print(f"MiSTerFin exited with status {process.returncode}. See {args.log}.", file=sys.stderr)
+        return process.returncode or 1
+    return 0
+
+
+def main() -> int:
+    return run(parse_args(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ghostty/test_ghostty_harness.py
+++ b/tools/ghostty/test_ghostty_harness.py
@@ -9,6 +9,7 @@ import importlib.util
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 MODULE_PATH = Path(__file__).with_name("ghostty_harness.py")
@@ -111,6 +112,18 @@ class FrameReadTests(unittest.TestCase):
             self.assertIsNone(HARNESS.read_complete_frame(path, 5))
             path.write_bytes(b"bad")
             self.assertIsNone(HARNESS.read_complete_frame(path, 5))
+
+
+class ChildEnvironmentTests(unittest.TestCase):
+    def test_desktop_cache_root_is_set_by_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            env = HARNESS.child_environment(640, 288, Path("/tmp/frame.raw"))
+        self.assertEqual(env["MISTERFIN_CACHE_ROOT"], "/tmp/misterfin-cache")
+
+    def test_explicit_cache_root_is_preserved(self):
+        with patch.dict("os.environ", {"MISTERFIN_CACHE_ROOT": "/tmp/custom-cache"}, clear=True):
+            env = HARNESS.child_environment(640, 240, Path("/tmp/frame.raw"))
+        self.assertEqual(env["MISTERFIN_CACHE_ROOT"], "/tmp/custom-cache")
 
 
 if __name__ == "__main__":

--- a/tools/ghostty/test_ghostty_harness.py
+++ b/tools/ghostty/test_ghostty_harness.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Unit tests for the Ghostty framebuffer presenter."""
+
+from __future__ import annotations
+
+import base64
+import io
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("ghostty_harness.py")
+SPEC = importlib.util.spec_from_file_location("ghostty_harness", MODULE_PATH)
+assert SPEC and SPEC.loader
+HARNESS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HARNESS)
+
+
+class ConversionTests(unittest.TestCase):
+    def test_bgrx_to_rgb_reorders_pixels(self):
+        frame = bytes((3, 2, 1, 0, 30, 20, 10, 255))
+        self.assertEqual(
+            HARNESS.bgrx_to_rgb(frame, 2, 1),
+            bytes((1, 2, 3, 10, 20, 30)),
+        )
+
+    def test_bgrx_to_rgb_rejects_wrong_size(self):
+        with self.assertRaisesRegex(ValueError, "expected 8 frame bytes"):
+            HARNESS.bgrx_to_rgb(b"short", 2, 1)
+
+
+class ProtocolTests(unittest.TestCase):
+    def test_empty_command_has_no_continuation_field(self):
+        chunks = list(HARNESS.kitty_chunks("a=d,d=i,i=1"))
+        self.assertEqual(chunks, [b"\x1b_Ga=d,d=i,i=1;\x1b\\"])
+
+    def test_payload_is_split_and_reassembles(self):
+        payload = bytes(range(256)) * 40
+        chunks = list(HARNESS.kitty_chunks("a=T,f=24", payload))
+
+        self.assertGreater(len(chunks), 1)
+        self.assertIn(b"a=T,f=24,m=1;", chunks[0])
+        self.assertIn(b"m=0;", chunks[-1])
+
+        encoded = b"".join(chunk.split(b";", 1)[1][:-2] for chunk in chunks)
+        self.assertEqual(base64.b64decode(encoded), payload)
+
+    def test_second_frame_is_placed_before_the_old_image_is_deleted(self):
+        tty = io.BytesIO()
+        presenter = HARNESS.GhosttyPresenter(tty, 1, 1)
+        original_geometry = HARNESS.terminal_geometry
+        HARNESS.terminal_geometry = lambda _tty: (80, 24, 0, 0)
+        try:
+            presenter.show(bytes((3, 2, 1, 0)))
+            first_output = tty.getvalue()
+            tty.seek(0)
+            tty.truncate()
+
+            presenter.show(bytes((6, 5, 4, 0)))
+            second_output = tty.getvalue()
+        finally:
+            HARNESS.terminal_geometry = original_geometry
+
+        self.assertIn(b"a=T", first_output)
+        self.assertNotIn(b"a=d", first_output)
+        self.assertIn(b"a=t", second_output)
+        self.assertIn(b"a=p", second_output)
+        self.assertIn(b"a=d", second_output)
+        self.assertLess(second_output.index(b"a=p"), second_output.index(b"a=d"))
+
+    def test_placement_enforces_the_four_by_three_cell_rectangle(self):
+        tty = io.BytesIO()
+        presenter = HARNESS.GhosttyPresenter(tty, 640, 288)
+        original_geometry = HARNESS.terminal_geometry
+        HARNESS.terminal_geometry = lambda _tty: (80, 24, 0, 0)
+        try:
+            presenter.show(bytes(640 * 288 * 4))
+        finally:
+            HARNESS.terminal_geometry = original_geometry
+
+        control = tty.getvalue().split(b";", 1)[0]
+        self.assertIn(b",c=64,r=24,", control)
+
+
+class GeometryTests(unittest.TestCase):
+    def test_four_by_three_image_fits_typical_terminal_cells(self):
+        self.assertEqual(HARNESS.display_cells(80, 24), (64, 24))
+
+    def test_image_is_limited_by_terminal_height(self):
+        self.assertEqual(HARNESS.display_cells(120, 10), (27, 10))
+
+    def test_reported_pixel_geometry_is_used(self):
+        self.assertEqual(
+            HARNESS.display_cells(100, 40, 1000, 800),
+            (100, 38),
+        )
+
+
+class FrameReadTests(unittest.TestCase):
+    def test_complete_frame_is_returned(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "frame.raw"
+            path.write_bytes(b"frame")
+            self.assertEqual(HARNESS.read_complete_frame(path, 5), b"frame")
+
+    def test_missing_and_short_frames_are_ignored(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "frame.raw"
+            self.assertIsNone(HARNESS.read_complete_frame(path, 5))
+            path.write_bytes(b"bad")
+            self.assertIsNone(HARNESS.read_complete_frame(path, 5))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run-local.sh
+++ b/tools/run-local.sh
@@ -52,6 +52,8 @@ make --no-print-directory
 
 export MISTERFIN_FB="${WIDTH}x${HEIGHT}"
 export MISTERFIN_FRAME_OUT="$RAW"
+: "${MISTERFIN_CACHE_ROOT:=/tmp/misterfin-cache}"
+export MISTERFIN_CACHE_ROOT
 
 if [ -n "$KEYS" ]; then
     export MISTERFIN_KEYS="$KEYS"


### PR DESCRIPTION
## Overview

The existing desktop harness renders MiSTerFin into a headless framebuffer and can save its final state as a PNG, but it does not provide a live visual surface for interactive development. This adds an optional Ghostty harness that presents the real framebuffer as a smooth, interactive image using the Kitty graphics protocol.

The desktop harnesses also previously inherited MiSTer-only artwork cache paths under `/media/fat/misterfin`. Cover and grid downloads therefore could not be persisted on a normal Linux desktop, leaving browse posters, backdrops and home-screen mosaics blank. This PR makes the cache root configurable and gives both desktop launchers a usable default.

## Changes

- Add a self-contained `tools/ghostty/` helper, documentation and unit tests.
- Reuse MiSTerFin's existing headless framebuffer and terminal input backends.
- Double-buffer terminal images so a complete new frame is placed before the old frame is removed.
- Present the PAL and NTSC framebuffers at their intended physical 4:3 aspect ratio rather than treating their CRT pixels as square.
- Ignore partial and duplicate framebuffer reads and cap terminal presentation independently of MiSTerFin's frame loop.
- Keep program output out of the image by writing it to `/tmp/misterfin-ghostty.log`.
- Map literal keyboard A and B to the matching on-screen MiSTer button labels while retaining the existing Enter/X and Escape/Z alternatives.
- Add `MISTERFIN_CACHE_ROOT` as the shared root for cover and grid caches.
- Preserve `/media/fat/misterfin` as the default on MiSTer, so production cache paths and behavior remain unchanged.
- Set `/tmp/misterfin-cache` as the overridable default in both `run-local.sh` and the Ghostty helper.
- Validate cache paths and directory creation, and reject truncated or invalid child paths.
- Ignore the optional local `debug.log`.
- Document the helper and cache setting in the development README and run the Ghostty tests from `make test`.

Video playback remains unavailable in the desktop harness because `mplayer` opens `/dev/fb0` directly. Browsing, artwork, menus, setup and metadata are interactive.

## Testing

- `make`
- `python3 -m unittest tools/ghostty/test_ghostty_harness.py` — 13 tests passed
- `tests/test_hero.c` — 3,134 checks passed
- `tests/test_cache_sweep.c` — 28 checks passed, including default and overridden cache roots
- JSON, subtitle, configuration and Jellyfin query suites passed
- Live Ghostty testing confirmed smooth updates, keyboard navigation, correct 4:3 presentation and artwork rendering
- A clean real-server cache run downloaded 151 cover/backdrop files and 10 grid-cache files; the selected movie poster and backdrop rendered correctly
- The ARM build was deployed and verified on a real MiSTer with unchanged production cache paths

The existing sound test does not complete on this Linux desktop because `libasound.so.2` is installed and the test explicitly asserts the no-libasound path. The test's own comment documents that host assumption. This change does not modify the sound subsystem.