### PR TITLE
Preserve Quick Connect tokens during startup connection failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ test:
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_jellyfin_queries \
 		tests/test_jellyfin_queries.c src/jellyfin.c src/json.c
 	@/tmp/misterfin_test_jellyfin_queries
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_jellyfin_auth \
+		tests/test_jellyfin_auth.c src/jellyfin.c src/json.c
+	@/tmp/misterfin_test_jellyfin_auth
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_sfx tests/test_sfx.c -lpthread
 	@/tmp/misterfin_test_sfx
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_hero tests/test_hero.c src/draw.c

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -699,7 +699,7 @@ pid_t jf_spawn_stream_curl(const JfConfig *cfg, const char *url, const char *fif
 
 static char *jf_request_alloc(const JfConfig *cfg, const char *method,
                                const char *path_and_query, const char *body_file,
-                               int timeout_secs)
+                               int timeout_secs, long *http_status)
 {
     char auth[320];
     jf_auth_header(cfg, auth, sizeof(auth));
@@ -722,6 +722,14 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
     n = jf_add_tls_args(cfg, argv, n);
     argv[n++] = "--max-time";
     argv[n++] = timeout;
+    if (http_status) {
+        /* Keep the status out of the response body for normal requests. The
+         * saved-token probe needs it to distinguish a rejected credential
+         * from a server or network failure, but every other caller only
+         * needs curl's usual success/failure result. */
+        argv[n++] = "--write-out";
+        argv[n++] = "\n%{http_code}";
+    }
     if (method) { argv[n++] = "-X"; argv[n++] = method; }
     argv[n++] = "-H";
     argv[n++] = auth;
@@ -740,6 +748,22 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
     char *result = jf_curl_run((char *const *)argv, 1, &ok);
     clock_gettime(CLOCK_MONOTONIC, &t1);
 
+    if (http_status) {
+        *http_status = 0;
+        if (result) {
+            char *status_line = strrchr(result, '\n');
+            if (status_line && strlen(status_line + 1) == 3) {
+                char *end = NULL;
+                long parsed = strtol(status_line + 1, &end, 10);
+                if (end && *end == '\0') {
+                    *http_status = parsed;
+                    *status_line = '\0';
+                    if (result[0] == '\0') { free(result); result = NULL; }
+                }
+            }
+        }
+    }
+
     double elapsed_ms = (t1.tv_sec - t0.tv_sec) * 1000.0 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
     /* ok alone, not "ok && result != NULL": a 204 No Content (the normal
      * response for the Sessions/Playing family) has an empty body, so
@@ -757,7 +781,7 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
 static int jf_fetch(const JfConfig *cfg, const char *path_and_query, JfResponse *r)
 {
     memset(r, 0, sizeof(*r));
-    r->text = jf_request_alloc(cfg, NULL, path_and_query, NULL, 8);
+    r->text = jf_request_alloc(cfg, NULL, path_and_query, NULL, 8, NULL);
     if (!r->text) return 0;
     if (!json_parse(&r->doc, r->text)) { jf_response_free(r); return 0; }
     return 1;
@@ -786,7 +810,7 @@ static void jf_post_json(const JfConfig *cfg, const char *path, const char *json
     /* Reuses the same no-shell path as every other request — see
      * jf_curl_run. The response is discarded, but the arguments still carry
      * the server-issued token. */
-    if (ok) free(jf_request_alloc(cfg, "POST", path, tmp_path, 5));
+    if (ok) free(jf_request_alloc(cfg, "POST", path, tmp_path, 5, NULL));
     unlink(tmp_path);
 }
 
@@ -1065,7 +1089,7 @@ static int jf_post_fetch(const JfConfig *cfg, const char *path,
         if (!ok) { unlink(tmp_path); return 0; }
     }
 
-    r->text = jf_request_alloc(cfg, "POST", path, json_body ? tmp_path : NULL, 10);
+    r->text = jf_request_alloc(cfg, "POST", path, json_body ? tmp_path : NULL, 10, NULL);
     if (json_body) unlink(tmp_path);
 
     if (!r->text) return 0;
@@ -1158,21 +1182,31 @@ int jf_quick_connect_authenticate(JfConfig *cfg, const JfQuickConnect *qc)
     return 1;
 }
 
-int jf_credential_works(const JfConfig *cfg)
+JfCredentialStatus jf_credential_status(const JfConfig *cfg)
 {
-    if (!jf_has_credential(cfg) || !cfg->user_id[0]) return 0;
+    if (!jf_has_credential(cfg) || !cfg->user_id[0]) return JF_CREDENTIAL_REJECTED;
 
     /* UserViews is the smallest authenticated, user-scoped call available —
-     * it fails for a revoked token but doesn't need elevated access the way
-     * /Users does. */
+     * it doesn't need elevated access the way /Users does. Ask curl for the
+     * HTTP status here so an explicit rejection remains distinguishable from
+     * a reboot-time network race, timeout, or server error. */
     char path[256];
     snprintf(path, sizeof(path), "/UserViews?userId=%s", cfg->user_id);
 
-    JfResponse r;
-    if (!jf_fetch(cfg, path, &r)) return 0;
-    int ok = json_find(&r.doc, NULL, "Items") != NULL;
+    JfResponse r = {0};
+    long http_status = 0;
+    r.text = jf_request_alloc(cfg, NULL, path, NULL, 8, &http_status);
+    if (http_status == 401 || http_status == 403) {
+        free(r.text);
+        return JF_CREDENTIAL_REJECTED;
+    }
+    if (http_status != 200 || !r.text || !json_parse(&r.doc, r.text)) {
+        jf_response_free(&r);
+        return JF_CREDENTIAL_UNAVAILABLE;
+    }
+    int valid = json_find(&r.doc, NULL, "Items") != NULL;
     jf_response_free(&r);
-    return ok;
+    return valid ? JF_CREDENTIAL_VALID : JF_CREDENTIAL_UNAVAILABLE;
 }
 
 int jf_resolve_user_id(JfConfig *cfg)

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -325,9 +325,16 @@ int jf_token_save(const JfConfig *cfg);
 int jf_token_load(JfConfig *cfg);
 void jf_token_clear(void);
 
-/* Cheap authenticated request, to tell a still-valid saved token from one the
- * server has since revoked. Returns 1 if the credential works. */
-int jf_credential_works(const JfConfig *cfg);
+typedef enum {
+    JF_CREDENTIAL_UNAVAILABLE = -1,
+    JF_CREDENTIAL_REJECTED = 0,
+    JF_CREDENTIAL_VALID = 1
+} JfCredentialStatus;
+
+/* Cheap authenticated request to validate a saved token. A 401/403 means the
+ * server explicitly rejected it; transport failures and other server errors
+ * remain distinct so startup does not erase a valid token during an outage. */
+JfCredentialStatus jf_credential_status(const JfConfig *cfg);
 
 /* Looks up cfg->username in GET /Users and fills in cfg->user_id. The raw
  * Jellyfin user id (a GUID) is not something a user can easily find in the

--- a/src/main.c
+++ b/src/main.c
@@ -4967,12 +4967,22 @@ static void *startup_resolve_thread(void *arg)
 
     jf_log_init(&g_cfg);   /* no-op unless "DEBUGLOG" is in jellyfin.conf */
 
-    if (jf_token_load(&g_cfg) && jf_credential_works(&g_cfg)) {
+    int saved_token = jf_token_load(&g_cfg);
+    JfCredentialStatus token_status = saved_token
+        ? jf_credential_status(&g_cfg) : JF_CREDENTIAL_REJECTED;
+    if (token_status == JF_CREDENTIAL_VALID) {
         /* A previously earned Quick Connect token, still accepted. Checked
          * before the config's API key so that re-authenticating once sticks
          * even if a stale key is left in the file. */
         result = 1;
         startup_enter_browse();
+    } else if (token_status == JF_CREDENTIAL_UNAVAILABLE) {
+        /* A timeout or unreachable server says nothing about whether the
+         * credential is still valid. Keep token.conf so a reboot-time network
+         * race cannot turn a temporary connection failure into a forced new
+         * Quick Connect login. */
+        jf_log_line("startup: saved token validation unavailable; token retained");
+        result = 0;
     } else if (g_cfg.api_key[0] && g_cfg.username[0]) {
         /* Classic path: an admin-issued API key plus a username to resolve.
          * jf_token_load may have overwritten the credential with a dead
@@ -4982,9 +4992,9 @@ static void *startup_resolve_thread(void *arg)
         result = jf_resolve_user_id(&g_cfg);
         if (result == 1) startup_enter_browse();
     } else {
-        /* No usable credential — a saved token that no longer works ends up
-         * here too, which is what makes a revoked or expired login recover by
-         * itself instead of showing an error nobody can act on. */
+        /* No usable credential — an explicitly rejected saved token ends up
+         * here too, which makes a revoked login recover by itself instead of
+         * showing an error nobody can act on. */
         jf_token_clear();
         g_cfg.token[0] = '\0';
         g_cfg.user_id[0] = '\0';

--- a/tests/test_jellyfin_auth.c
+++ b/tests/test_jellyfin_auth.c
@@ -1,0 +1,105 @@
+/* Saved-token validation tests. A tiny one-shot HTTP server exercises the
+ * real curl transport so the distinction between accepted, rejected, and
+ * temporarily unavailable credentials cannot drift away from HTTP behavior. */
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "jellyfin.h"
+
+static int fails;
+static int checks;
+
+static void check(const char *label, int got, int expected)
+{
+    checks++;
+    if (got != expected) {
+        fails++;
+        printf("  FAIL %s: got %d, want %d\n", label, got, expected);
+    }
+}
+
+static pid_t start_server(int status, const char *body, int *port)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0 || listen(fd, 1) != 0) {
+        close(fd);
+        return -1;
+    }
+
+    socklen_t len = sizeof(addr);
+    if (getsockname(fd, (struct sockaddr *)&addr, &len) != 0) {
+        close(fd);
+        return -1;
+    }
+    *port = ntohs(addr.sin_port);
+
+    pid_t pid = fork();
+    if (pid != 0) {
+        close(fd);
+        return pid;
+    }
+
+    int client = accept(fd, NULL, NULL);
+    if (client >= 0) {
+        char request[2048];
+        ssize_t received = read(client, request, sizeof(request));
+        if (received < 0) _exit(1);
+        const char *reason = status == 200 ? "OK" :
+                             status == 401 ? "Unauthorized" :
+                             status == 403 ? "Forbidden" : "Service Unavailable";
+        char response[1024];
+        int n = snprintf(response, sizeof(response),
+                         "HTTP/1.1 %d %s\r\nContent-Type: application/json\r\n"
+                         "Content-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                         status, reason, strlen(body), body);
+        ssize_t sent = write(client, response, (size_t)n);
+        if (sent != n) _exit(1);
+        close(client);
+    }
+    close(fd);
+    _exit(0);
+}
+
+static void run_case(const char *label, int http_status, const char *body,
+                     JfCredentialStatus expected)
+{
+    int port = 0;
+    pid_t server = start_server(http_status, body, &port);
+    if (server < 0) {
+        check(label, JF_CREDENTIAL_UNAVAILABLE, expected);
+        return;
+    }
+
+    JfConfig cfg = {0};
+    snprintf(cfg.server, sizeof(cfg.server), "http://127.0.0.1:%d", port);
+    snprintf(cfg.token, sizeof(cfg.token), "test-token");
+    snprintf(cfg.user_id, sizeof(cfg.user_id), "test-user");
+    snprintf(cfg.device_id, sizeof(cfg.device_id), "test-device");
+
+    check(label, jf_credential_status(&cfg), expected);
+    waitpid(server, NULL, 0);
+}
+
+int main(void)
+{
+    run_case("accepted token", 200, "{\"Items\":[]}", JF_CREDENTIAL_VALID);
+    run_case("401 rejects token", 401, "", JF_CREDENTIAL_REJECTED);
+    run_case("403 rejects token", 403, "", JF_CREDENTIAL_REJECTED);
+    run_case("server error preserves token", 503, "", JF_CREDENTIAL_UNAVAILABLE);
+    run_case("malformed success preserves token", 200, "not json", JF_CREDENTIAL_UNAVAILABLE);
+
+    printf("jellyfin auth: %d checks, %d failures\n", checks, fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Overview

MiSTerFin validates a saved Quick Connect token with `/UserViews` during startup. The existing boolean result treats every failed request as a rejected credential, deletes `token.conf`, and starts Quick Connect again. On MiSTer, this can happen after a reboot when the application starts before the network or Jellyfin server is ready.

This change distinguishes an explicit authentication rejection from a temporary validation failure:

- Capture the HTTP status for the saved-token validation request.
- Treat HTTP 401 and 403 as rejected credentials and clear the saved token.
- Preserve `token.conf` for timeouts, connection failures, server errors, unexpected statuses, and malformed responses.
- Show the existing connection-failure path for temporary failures so a later launch can retry the same token.
- Log that validation was unavailable and the token was retained when debug logging is enabled.

Normal requests retain their existing transport behavior. Only the saved-token probe requests the HTTP status.

## Tests

Added a local one-shot HTTP server test covering:

- HTTP 200 with a valid `/UserViews` response
- HTTP 401
- HTTP 403
- HTTP 503
- HTTP 200 with malformed JSON

`make` passes. The new authentication test passes all 5 checks. Existing JSON, subtitle, configuration, query, hero, and cache-sweep tests also pass. On my development host, the full `make test` target stops at the pre-existing `test_sfx` no-ALSA assertion because `libasound` is installed; this change does not touch audio code.