### PR TITLE
Add provider-independent Jellyfin Live TV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="docs/hero.png" width="100%" alt="MiSTerFin screenshot collage"></p>
 
-A [Jellyfin](https://jellyfin.org) client for the [MiSTer FPGA](https://misterfpga.org) platform. Browse your Movies/TV/Music library, see cover art and overview, and play back on a CRT — video is server-side transcoded and letterboxed to PAL or NTSC, with client-side subtitles, full pause/seek/resume support, and a proper music player with a now-playing screen. Works with whatever analog output your MiSTer is already set up for (SCART, composite, component, ...) — MiSTerFin just writes to the standard framebuffer, same as any other MiSTer app.
+A [Jellyfin](https://jellyfin.org) client for the [MiSTer FPGA](https://misterfpga.org) platform. Browse your Movies/TV/Music libraries and Live TV channels, see cover art and overview, and play back on a CRT — video is server-side transcoded and letterboxed to PAL or NTSC, with client-side subtitles, full pause/seek/resume support for library video, and a proper music player with a now-playing screen. Works with whatever analog output your MiSTer is already set up for (SCART, composite, component, ...) — MiSTerFin just writes to the standard framebuffer, same as any other MiSTer app.
 
 Having trouble getting it onto a CRT? Check [docs/DISPLAY_COMPATIBILITY.md](docs/DISPLAY_COMPATIBILITY.md) for confirmed working display/cable/`MiSTer.ini` combinations.
 
@@ -93,6 +93,7 @@ All captured in-app via the [SELECT+START screenshot combo](#controls), straight
 - **Browsing within a library** (movies/series/albums/episodes/tracks) uses a list with cover art per item, watched/resume badges, a live clock, and a scrolling marquee for titles too long to fit (e.g. "Artist / Album", "Series / Season"). Albums show year + track count, artists show album count, and series show season + episode count
 - **Info screen** with cover art, description, year, and status
 - **Video playback** is server-side transcoded with correct letterbox/pillarbox scaling for any source aspect ratio
+- **Live TV** lists the authenticated user's Jellyfin channels in server order, shows each channel's current program, and uses Jellyfin's provider-independent playback negotiation and session-reporting flow to request a MiSTer-compatible stream
 - **True interlaced output (576i/480i)** is possible on a CRT TV — smoother, broadcast-style motion instead of the scanline look, and genuinely tear-free thanks to a hardware page-flip technique. It runs on a standalone core that doesn't touch any MiSTer system files, switched live with a button combo: see the [step-by-step guide](docs/DISPLAY_COMPATIBILITY.md#interlaced-output), confirmed working over SCART and Component/YPbPr, both PAL and NTSC
 - **Pause menu** with a live progress bar, VSync ON/OFF toggle, resume/stop
 - **Subtitles** are rendered client-side (instant toggle/switch, no re-buffering) for text-based tracks, with a picker menu and live sync fine-tuning; image-based tracks (PGS/VobSub — no text to hand back client-side) fall back to a server-side burn-in automatically instead of silently failing to show. ASS/SSA subtitles are cleaned up on the way in — inline override codes like `{\an8}` and `{\i1}` are stripped rather than drawn on screen as literal text
@@ -105,7 +106,7 @@ All captured in-app via the [SELECT+START screenshot combo](#controls), straight
 
 ## <a id="scope"></a>Scope (v1)
 
-- Movies, TV shows, Music, and Music Videos — no photo libraries
+- Movies, TV shows, Music, Music Videos, and Jellyfin Live TV — no photo libraries
 - Server-side transcode for video (the MiSTer's ARM Cortex-A9 can't decode arbitrary HEVC/4K sources locally) to a CRT-sized stream, then letterboxed/pillarboxed client-side to exactly fill the PAL/NTSC frame
 - Audio plays back directly (`static=true`, no server transcode) — this mplayer build decodes FLAC/MP3 natively, and there's no letterboxing concern for audio the way there is for video
 
@@ -333,8 +334,9 @@ A keyboard works standalone, with no gamepad attached.
 
 ## <a id="known-limitations"></a>Known limitations
 
-Verified against a real Jellyfin 10.11 server: auth, browsing (views/items, including Music), resume position, cover art, subtitles, video playback (transcoded over TS), and music playback (direct-played FLAC/MP3) all confirmed working end-to-end on real MiSTer hardware.
+Verified against a real Jellyfin 10.11 server: auth, browsing (views/items, including Music), resume position, cover art, subtitles, video playback (transcoded over TS), music playback (direct-played FLAC/MP3), and Live TV channel browsing/playback all confirmed working end-to-end on real MiSTer hardware.
 
+- **Live TV currently covers channel browsing and playback, not the full TV experience.** It requires a working Live TV source already configured in Jellyfin. MiSTerFin uses only Jellyfin's standard Live TV and playback APIs, so the implementation is provider-agnostic. Playback has been tested with Jellyfin's built-in HDHomeRun integration; other Jellyfin Live TV providers should work but have not yet been verified. There is no program-grid view, recording management, pause, seek, or track picker during a live stream.
 - **`playSessionId` is required on the video stream URL.** Without it, Jellyfin can silently serve back a stale cached transcode from an earlier request instead of honoring the current `maxWidth`/`maxHeight`/`videoBitRate` — confirmed on a real server. Already handled in `jf_stream_url()`.
 - **Hardware-accelerated server transcoding (QSV/NVENC/VAAPI) may be broken on the user's server and is outside this client's control.** If `/Videos/{id}/stream` returns HTTP 500, check the Jellyfin server log (`/System/Logs`) for `FfmpegException` — if the ffmpeg command line shows `h264_qsv`/`h264_nvenc`/`vaapi`, the fix is server-side: Dashboard → Playback → Transcoding → Hardware acceleration → None (or fix the GPU driver).
 - **No NEON-accelerated colorspace conversion in this mplayer/ffmpeg build.** Total pixel count (resolution) is what actually costs CPU, not bitrate — confirmed on hardware that doubling `videoBitRate` at a fixed resolution moved average CPU usage by only ~1 percentage point, while trying native PAL resolution (720x576) instead of the default 480x270 caused continuously growing A/V desync and pegged the CPU. Keep the transcode resolution small and spend bitrate freely on quality instead; let mplayer's own `-vf` scale it back up, which is cheap relative to decode.

--- a/src/grid.c
+++ b/src/grid.c
@@ -292,7 +292,9 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
     JfItem grid_items[GRID_FETCH_MAX];
     int n;
 
-    if (view_is_synthetic(view)) {
+    if (view_is_live_tv(view)) {
+        n = 0;   /* channel images are logos, not a useful poster mosaic */
+    } else if (view_is_synthetic(view)) {
         /* No ParentId to list under — the covers are just the row's own
          * items. Deliberately not disk-cached either: the whole point of
          * these rows is that they change as things get watched, so a cache
@@ -332,7 +334,7 @@ static void grid_cache_populate(GridLibCache *gc, const JfItem *view,
         }
     }
     grid_cell_order_shuffle(gc);
-    if (!view_is_synthetic(view)) {
+    if (!view_is_synthetic(view) && !view_is_live_tv(view)) {
         int64_t count = jf_count_items(s_cfg, view->id, item_type);
         if (count >= 0) grid_cache_save_to_disk(gc, view->id, count, cell_w);
     }

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -288,6 +288,8 @@ static void parse_item_fields(const JsonDoc *doc, const JsonNode *item, JfItem *
     else if (!strcmp(type_buf, "MusicArtist"))   it->type = JF_TYPE_ARTIST;
     else if (!strcmp(type_buf, "MusicAlbum"))    it->type = JF_TYPE_ALBUM;
     else if (!strcmp(type_buf, "Audio"))         it->type = JF_TYPE_TRACK;
+    else if (!strcmp(type_buf, "TvChannel") ||
+             !strcmp(type_buf, "LiveTvChannel")) it->type = JF_TYPE_LIVE_CHANNEL;
     else if (!strcmp(type_buf, "CollectionFolder") ||
              !strcmp(type_buf, "Folder"))        it->type = JF_TYPE_FOLDER;
     else                                          it->type = JF_TYPE_OTHER;
@@ -298,6 +300,14 @@ static void parse_item_fields(const JsonDoc *doc, const JsonNode *item, JfItem *
     }
     if (it->type == JF_TYPE_EPISODE)
         copy_display_str(doc, item, "SeriesName", it->series_name, sizeof(it->series_name));
+    if (it->type == JF_TYPE_LIVE_CHANNEL) {
+        if (!copy_display_str(doc, item, "Number", it->channel_number,
+                              sizeof(it->channel_number)))
+            copy_display_str(doc, item, "ChannelNumber", it->channel_number,
+                             sizeof(it->channel_number));
+        copy_display_str(doc, item, "CurrentProgram.Name", it->current_program,
+                         sizeof(it->current_program));
+    }
 
     copy_raw_str(doc, item, "CollectionType", it->collection_type, sizeof(it->collection_type));
 
@@ -616,7 +626,7 @@ void jf_log_line(const char *fmt, ...)
  * secret, an ApiKey on a media URL) lands after that character, so the cut
  * removes it regardless of which endpoint this is. */
 static void jf_log_request(const char *method, const char *path_and_query,
-                            int ok, double elapsed_ms, long bytes)
+                            int ok, int http_status, double elapsed_ms, long bytes)
 {
     if (!g_jf_log) return;
 
@@ -630,9 +640,9 @@ static void jf_log_request(const char *method, const char *path_and_query,
     char ts[16];
     strftime(ts, sizeof(ts), "%H:%M:%S", localtime(&now));
 
-    fprintf(g_jf_log, "[%s] %-4s %-48s %-4s %6.0fms %6ld bytes\n",
+    fprintf(g_jf_log, "[%s] %-4s %-48s %-4s http=%03d %6.0fms %6ld bytes\n",
             ts, method ? method : "GET", path_only,
-            ok ? "ok" : "FAIL", elapsed_ms, bytes);
+            ok ? "ok" : "FAIL", http_status, elapsed_ms, bytes);
     fflush(g_jf_log);   /* request rate is low; a crash right after must not lose this line */
 }
 
@@ -715,7 +725,7 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
 
     /* Built as a plain argv. Each element reaches curl exactly as written,
      * with no quoting, escaping or word splitting anywhere in between. */
-    const char *argv[24];
+    const char *argv[26];
     int n = 0;
     argv[n++] = "curl";
     argv[n++] = "-sf";
@@ -731,6 +741,8 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
         argv[n++] = "--data-binary";
         argv[n++] = body_arg;
     }
+    argv[n++] = "--write-out";
+    argv[n++] = "\n%{http_code}";
     argv[n++] = url;
     argv[n]   = NULL;
 
@@ -745,8 +757,23 @@ static char *jf_request_alloc(const JfConfig *cfg, const char *method,
      * response for the Sessions/Playing family) has an empty body, so
      * result is NULL even though curl's own exit status says the request
      * succeeded — logging that as FAIL was blaming the wrong thing. */
-    jf_log_request(method, path_and_query, ok, elapsed_ms,
-                    result ? (long)strlen(result) : 0);
+    int http_status = 0;
+    long body_bytes = 0;
+    if (result) {
+        size_t len = strlen(result);
+        if (len >= 4 && result[len - 4] == '\n' &&
+            result[len - 3] >= '0' && result[len - 3] <= '9' &&
+            result[len - 2] >= '0' && result[len - 2] <= '9' &&
+            result[len - 1] >= '0' && result[len - 1] <= '9') {
+            http_status = (result[len - 3] - '0') * 100 +
+                          (result[len - 2] - '0') * 10 +
+                          (result[len - 1] - '0');
+            result[len - 4] = '\0';
+        }
+        body_bytes = (long)strlen(result);
+        if (!body_bytes) { free(result); result = NULL; }
+    }
+    jf_log_request(method, path_and_query, ok, http_status, elapsed_ms, body_bytes);
 
     return result;
 }
@@ -1196,6 +1223,8 @@ int jf_resolve_user_id(JfConfig *cfg)
 
 /* ── browsing ─────────────────────────────────────────────────────────────── */
 
+static void parse_total_count(const JsonDoc *doc, int64_t *total_out);
+
 int jf_list_views(const JfConfig *cfg, JfItem *out, int max)
 {
     char path[256];
@@ -1207,6 +1236,40 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max)
     for (int i = 0; i < n; i++) out[i].type = JF_TYPE_FOLDER;
     jf_response_free(&r);
     return n;
+}
+
+void jf_build_live_tv_channels_path(const JfConfig *cfg, int start_index, int max,
+                                     char *path, size_t path_size)
+{
+    if (start_index < 0) start_index = 0;
+    snprintf(path, path_size,
+        "/LiveTv/Channels?userId=%s&StartIndex=%d&Limit=%d"
+        "&AddCurrentProgram=true"
+        "&EnableImages=true&ImageTypeLimit=1&EnableImageTypes=Primary",
+        cfg->user_id, start_index, max);
+}
+
+int jf_list_live_tv_channels(const JfConfig *cfg, int start_index,
+                              JfItem *out, int max, int64_t *total_out)
+{
+    char path[384];
+    jf_build_live_tv_channels_path(cfg, start_index, max, path, sizeof(path));
+
+    JfResponse r;
+    if (!jf_fetch(cfg, path, &r)) return -1;
+    int n = parse_item_list(&r.doc, out, max);
+    parse_total_count(&r.doc, total_out);
+    for (int i = 0; i < n; i++) out[i].type = JF_TYPE_LIVE_CHANNEL;
+    jf_response_free(&r);
+    return n;
+}
+
+int jf_live_tv_available(const JfConfig *cfg)
+{
+    JfItem channel;
+    int64_t total = 0;
+    int n = jf_list_live_tv_channels(cfg, 0, &channel, 1, &total);
+    return n > 0 || total > 0;
 }
 
 int64_t jf_count_items(const JfConfig *cfg, const char *parent_id, const char *item_type)
@@ -1648,6 +1711,153 @@ int jf_stream_url(const JfConfig *cfg, const char *item_id,
     return 1;
 }
 
+void jf_build_live_tv_playback_info_path(const char *channel_id,
+                                          char *path, size_t path_size)
+{
+    char safe_channel[JF_ID_LEN];
+    jf_sanitize_id(channel_id, safe_channel, sizeof(safe_channel));
+    snprintf(path, path_size, "/Items/%s/PlaybackInfo", safe_channel);
+}
+
+int jf_build_live_tv_playback_info_body(const JfConfig *cfg,
+                                         const JfStreamProfile *profile,
+                                         char *out, int outlen)
+{
+    if (!cfg || !profile || !out || outlen <= 0) return 0;
+    int fps_cap = (strcasecmp(cfg->tv_mode, "NTSC") == 0) ? 30 : 25;
+    int n = snprintf(out, outlen,
+        "{\"UserId\":\"%s\",\"StartTimeTicks\":0,\"IsPlayback\":true,"
+        "\"AutoOpenLiveStream\":true,\"EnableDirectPlay\":false,"
+        "\"EnableDirectStream\":false,\"EnableTranscoding\":true,"
+        "\"AllowVideoStreamCopy\":false,\"AllowAudioStreamCopy\":false,"
+        "\"MaxStreamingBitrate\":%d,\"DeviceProfile\":{\"Name\":\"MiSTerFin\","
+        "\"MaxStreamingBitrate\":%d,\"MaxStaticBitrate\":%d,"
+        "\"DirectPlayProfiles\":[],\"TranscodingProfiles\":[{"
+        "\"Container\":\"ts\",\"Type\":\"Video\",\"Protocol\":\"http\","
+        "\"AudioCodec\":\"mp3\",\"VideoCodec\":\"mpeg2video\","
+        "\"Context\":\"Streaming\",\"MaxAudioChannels\":\"2\"}],"
+        "\"CodecProfiles\":[{\"Type\":\"Video\",\"Codec\":\"mpeg2video\","
+        "\"Conditions\":[{\"Condition\":\"LessThanEqual\","
+        "\"Property\":\"Width\",\"Value\":\"%d\",\"IsRequired\":true},{"
+        "\"Condition\":\"LessThanEqual\",\"Property\":\"Height\","
+        "\"Value\":\"%d\",\"IsRequired\":true},{\"Condition\":"
+        "\"LessThanEqual\",\"Property\":\"VideoFramerate\",\"Value\":"
+        "\"%d\",\"IsRequired\":true}]}],\"SubtitleProfiles\":[]}}",
+        cfg->user_id, profile->video_bitrate,
+        profile->video_bitrate, profile->video_bitrate,
+        profile->max_width, profile->max_height, fps_cap);
+    return n >= 0 && n < outlen;
+}
+
+int jf_live_tv_transcoding_url(const JfConfig *cfg, const char *transcoding_url,
+                                char *out, int outlen)
+{
+    if (!out || outlen <= 0) return 0;
+    out[0] = '\0';
+    if (!cfg || !transcoding_url || !transcoding_url[0]) return 0;
+
+    /* Jellyfin can inherit the source MPEG-2 level into this URL without a
+     * profile. Its ffmpeg builder then emits `-level` but deliberately strips
+     * MPEG-2 profiles, and the encoder rejects that incomplete pair before
+     * frame one. Remove only the unsupported level hint; Jellyfin retains all
+     * other negotiated live-stream and output constraints. */
+    char cleaned[JF_STREAM_URL_LEN];
+    const char *query = strchr(transcoding_url, '?');
+    size_t prefix_len = query ? (size_t)(query - transcoding_url) : strlen(transcoding_url);
+    if (prefix_len >= sizeof(cleaned)) return 0;
+    memcpy(cleaned, transcoding_url, prefix_len);
+    size_t used = prefix_len;
+    cleaned[used] = '\0';
+    int has_api_key = 0;
+
+    if (query) {
+        const char *p = query + 1;
+        int first = 1;
+        while (*p) {
+            const char *end = strchr(p, '&');
+            size_t len = end ? (size_t)(end - p) : strlen(p);
+            const char *equals = memchr(p, '=', len);
+            size_t key_len = equals ? (size_t)(equals - p) : len;
+            int is_level = (key_len == 5 && !strncasecmp(p, "level", 5)) ||
+                           (key_len == 16 && !strncasecmp(p, "mpeg2video-level", 16));
+            if (key_len == 6 && !strncasecmp(p, "ApiKey", 6))
+                has_api_key = 1;
+            if (!is_level) {
+                if (used + 1 + len >= sizeof(cleaned)) return 0;
+                cleaned[used++] = first ? '?' : '&';
+                memcpy(cleaned + used, p, len);
+                used += len;
+                cleaned[used] = '\0';
+                first = 0;
+            }
+            if (!end) break;
+            p = end + 1;
+        }
+    }
+
+    if (cleaned[0] != '/') return 0;
+    const char *separator = strchr(cleaned, '?') ? "&" : "?";
+    int n = has_api_key
+        ? snprintf(out, outlen, "%s%s", cfg->server, cleaned)
+        : snprintf(out, outlen, "%s%s%sApiKey=%s", cfg->server,
+                   cleaned, separator, cfg->token);
+    return n >= 0 && n < outlen;
+}
+
+int jf_open_live_tv_stream(const JfConfig *cfg, const char *channel_id,
+                            const JfStreamProfile *profile,
+                            JfLivePlayback *playback)
+{
+    if (!playback) return 0;
+    memset(playback, 0, sizeof(*playback));
+    if (!cfg || !channel_id || !channel_id[0] || !profile) return 0;
+
+    char path[384];
+    jf_build_live_tv_playback_info_path(channel_id, path, sizeof(path));
+
+    char body[1536];
+    if (!jf_build_live_tv_playback_info_body(cfg, profile, body, sizeof(body)))
+        return 0;
+
+    JfResponse r;
+    if (!jf_post_fetch(cfg, path, body, &r)) return 0;
+    copy_raw_str(&r.doc, NULL, "MediaSources[0].LiveStreamId",
+                 playback->live_stream_id, sizeof(playback->live_stream_id));
+    copy_raw_str(&r.doc, NULL, "MediaSources[0].Id",
+                 playback->media_source_id, sizeof(playback->media_source_id));
+    copy_raw_str(&r.doc, NULL, "PlaySessionId",
+                 playback->play_session_id, sizeof(playback->play_session_id));
+    char transcoding_url[JF_STREAM_URL_LEN] = "";
+    copy_raw_str(&r.doc, NULL, "MediaSources[0].TranscodingUrl",
+                 transcoding_url, sizeof(transcoding_url));
+    /* Like Jellyfin Web, consume the URL selected by PlaybackInfo instead of
+     * reconstructing a request or falling back to a raw tuner stream that the
+     * advertised device profile said this client cannot play. */
+    int url_ok = jf_live_tv_transcoding_url(cfg, transcoding_url,
+                                             playback->stream_url,
+                                             sizeof(playback->stream_url));
+    jf_response_free(&r);
+    if (playback->live_stream_id[0] && playback->media_source_id[0] &&
+        playback->play_session_id[0] && url_ok)
+        return 1;
+
+    /* AutoOpenLiveStream may have acquired a tuner before returning a response
+     * that this client cannot use. Release it on every validation failure. */
+    jf_close_live_tv_stream(cfg, playback->live_stream_id);
+    memset(playback, 0, sizeof(*playback));
+    return 0;
+}
+
+void jf_close_live_tv_stream(const JfConfig *cfg, const char *live_stream_id)
+{
+    if (!live_stream_id || !live_stream_id[0]) return;
+    char safe_id[JF_LIVE_ID_LEN];
+    jf_sanitize_id(live_stream_id, safe_id, sizeof(safe_id));
+    char path[JF_LIVE_ID_LEN + 64];
+    snprintf(path, sizeof(path), "/LiveStreams/Close?LiveStreamId=%s", safe_id);
+    free(jf_request_alloc(cfg, "POST", path, NULL, 5));
+}
+
 /* Codec strings per ffmpeg/Jellyfin's known text subtitle codecs — anything
  * not in this list is treated as image-based (safer default: an unknown
  * text codec would just fail jf_download_subtitle's fetch harmlessly via
@@ -1730,6 +1940,45 @@ static void build_playstate_json(const char *item_id, const char *play_session_i
         "\"PositionTicks\":%lld,\"IsPaused\":%s,\"PlayMethod\":\"%s\"}",
         safe_id, safe_session, (long long)position_ticks,
         is_paused ? "true" : "false", g_play_method);
+}
+
+int jf_build_live_tv_playstate_body(const JfLivePlayback *playback,
+                                     const char *item_id, int64_t position_ticks,
+                                     int paused, int failed,
+                                     char *out, int outlen)
+{
+    if (!out || outlen <= 0) return 0;
+    out[0] = '\0';
+    if (!playback || !item_id || !item_id[0] ||
+        !playback->media_source_id[0] || !playback->live_stream_id[0] ||
+        !playback->play_session_id[0])
+        return 0;
+
+    char safe_item[JF_ID_LEN], safe_source[JF_LIVE_ID_LEN];
+    char safe_live[JF_LIVE_ID_LEN], safe_session[64];
+    jf_sanitize_id(item_id, safe_item, sizeof(safe_item));
+    jf_sanitize_id(playback->media_source_id, safe_source, sizeof(safe_source));
+    jf_sanitize_id(playback->live_stream_id, safe_live, sizeof(safe_live));
+    jf_sanitize_id(playback->play_session_id, safe_session, sizeof(safe_session));
+    int n;
+    if (failed >= 0)
+        n = snprintf(out, outlen,
+            "{\"ItemId\":\"%s\",\"MediaSourceId\":\"%s\","
+            "\"LiveStreamId\":\"%s\",\"PlaySessionId\":\"%s\","
+            "\"PositionTicks\":%lld,\"IsPaused\":%s,\"PlayMethod\":\"Transcode\","
+            "\"CanSeek\":false,\"Failed\":%s}",
+            safe_item, safe_source, safe_live, safe_session,
+            (long long)position_ticks, paused ? "true" : "false",
+            failed ? "true" : "false");
+    else
+        n = snprintf(out, outlen,
+            "{\"ItemId\":\"%s\",\"MediaSourceId\":\"%s\","
+            "\"LiveStreamId\":\"%s\",\"PlaySessionId\":\"%s\","
+            "\"PositionTicks\":%lld,\"IsPaused\":%s,\"PlayMethod\":\"Transcode\","
+            "\"CanSeek\":false}",
+            safe_item, safe_source, safe_live, safe_session,
+            (long long)position_ticks, paused ? "true" : "false");
+    return n >= 0 && n < outlen;
 }
 
 void jf_report_start(const JfConfig *cfg, const char *item_id,
@@ -1830,6 +2079,36 @@ static void jf_post_json_async(const JfConfig *cfg, const char *path, const char
     }
 }
 
+void jf_report_live_tv_start(const JfConfig *cfg, const JfLivePlayback *playback,
+                              const char *item_id)
+{
+    char body[1024];
+    if (!jf_build_live_tv_playstate_body(playback, item_id, 0, 0, -1,
+                                          body, sizeof(body)))
+        return;
+    jf_post_json(cfg, "/Sessions/Playing", body);
+    jf_post_json(cfg, "/Sessions/Playing/Progress", body);
+}
+
+void jf_report_live_tv_progress(const JfConfig *cfg, const JfLivePlayback *playback,
+                                 const char *item_id, int64_t position_ticks)
+{
+    char body[1024];
+    if (jf_build_live_tv_playstate_body(playback, item_id, position_ticks, 0, -1,
+                                         body, sizeof(body)))
+        jf_post_json(cfg, "/Sessions/Playing/Progress", body);
+}
+
+void jf_report_live_tv_stopped(const JfConfig *cfg, const JfLivePlayback *playback,
+                                const char *item_id, int64_t position_ticks,
+                                int failed)
+{
+    char body[1024];
+    if (jf_build_live_tv_playstate_body(playback, item_id, position_ticks, 0,
+                                         failed, body, sizeof(body)))
+        jf_post_json_async(cfg, "/Sessions/Playing/Stopped", body);
+}
+
 void jf_report_stopped(const JfConfig *cfg, const char *item_id,
                         const char *play_session_id, int64_t position_ticks,
                         int played)
@@ -1875,6 +2154,10 @@ void jf_report_capabilities(const JfConfig *cfg)
 
 int view_is_resume(const JfItem *v)    { return v->synthetic == JF_SYNTH_RESUME; }
 int view_is_nextup(const JfItem *v)    { return v->synthetic == JF_SYNTH_NEXTUP; }
+int view_is_live_tv(const JfItem *v)
+{
+    return v->synthetic == JF_SYNTH_LIVE_TV || !strcmp(v->collection_type, "livetv");
+}
 int view_is_synthetic(const JfItem *v) { return v->synthetic != 0; }
 
 const char *collection_item_type(const char *collection_type)

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -2,11 +2,9 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-/* Jellyfin REST client — curl shelled out via popen(), no libcurl dependency.
- * All endpoints/params below were verified
- * against the official Jellyfin OpenAPI spec (see plan doc); a few optional
- * fields (MediaSourceId, PlaybackInfo negotiation) are intentionally omitted
- * rather than guessed — see README "Known limitations". */
+/* Jellyfin REST client — curl is executed directly, with no libcurl
+ * dependency. Endpoints and parameters are based on Jellyfin's API and the
+ * request flow used by Jellyfin Web. */
 
 #define JF_MAX_ITEMS   256
 /* How many items one browse request asks for. Smaller than JF_MAX_ITEMS on
@@ -23,6 +21,8 @@
  * the alternative is trusting a remote integer not to overflow int math. */
 #define JF_MAX_TOTAL_ITEMS 100000000
 #define JF_ID_LEN      40
+#define JF_LIVE_ID_LEN 256
+#define JF_STREAM_URL_LEN 1536
 #define JF_NAME_LEN    256
 #define JF_OVERVIEW_LEN 1024
 #define JF_PERSON_NAME_LEN 64
@@ -45,6 +45,7 @@ typedef enum {
     JF_TYPE_ARTIST,   /* MusicArtist — drills into albums, browsed like JF_TYPE_FOLDER */
     JF_TYPE_ALBUM,    /* MusicAlbum — drills into tracks, browsed like JF_TYPE_FOLDER */
     JF_TYPE_TRACK,    /* Audio — playable leaf, like JF_TYPE_MOVIE but audio-only */
+    JF_TYPE_LIVE_CHANNEL, /* TvChannel/LiveTvChannel — tuner-backed live stream */
     JF_TYPE_OTHER
 } JfItemType;
 
@@ -113,6 +114,8 @@ typedef struct {
      * essential for the Continue Watching / Next Up rows, where an episode
      * called "Episode 03" is otherwise unidentifiable. */
     char       series_name[JF_NAME_LEN];
+    char       channel_number[32];       /* Number/ChannelNumber — live channels only */
+    char       current_program[JF_NAME_LEN]; /* CurrentProgram.Name — live channels only */
     char       collection_type[16];  /* CollectionType — "movies"/"tvshows"/"music"/...,
                                        * library views only (jf_list_views), empty otherwise */
     JfItemType type;
@@ -394,26 +397,42 @@ int jf_list_items_recursive(const JfConfig *cfg, const char *parent_id,
  * this, refetching a fresh batch each time the current one runs out. */
 int jf_list_random_tracks(const JfConfig *cfg, const char *parent_id, JfItem *out, int max);
 
-/* Sentinel ids for the two synthetic home-screen entries. These aren't real
+/* Sentinel ids for the synthetic home-screen entries. These aren't real
  * library views — there is nothing on the server they correspond to — so they
  * get ids that cannot collide with a Jellyfin GUID while still surviving
  * jf_sanitize_id unchanged (which is what makes them safe as grid-cache
  * filenames). */
 #define JF_VIEW_RESUME  "misterfin-resume"
 #define JF_VIEW_NEXTUP  "misterfin-nextup"
+#define JF_VIEW_LIVE_TV "misterfin-live-tv"
 
 /* Values for JfItem.synthetic. The ids above remain as grid-cache keys; these
  * are what the code actually branches on. */
 #define JF_SYNTH_RESUME 1
 #define JF_SYNTH_NEXTUP 2
+#define JF_SYNTH_LIVE_TV 3
 
-/* The two home rows are presented as extra cards on the library carousel, but
- * they aren't libraries — no ParentId to list, no collection type, and their
- * contents change every time something is watched. Everything that would
- * normally reach for the server via a view id has to route around them. */
+/* Synthetic entries are extra cards on the library carousel, but they are
+ * not library views and have no ParentId or collection type. Everything that
+ * would normally reach for the server through a view id must route around
+ * them to the corresponding home-row or Live TV endpoint. */
 int view_is_resume(const JfItem *v);
 int view_is_nextup(const JfItem *v);
+int view_is_live_tv(const JfItem *v);
 int view_is_synthetic(const JfItem *v);
+
+/* Returns 1 when the authenticated user has at least one visible Live TV
+ * channel, 0 when Live TV is unavailable or empty. */
+int jf_live_tv_available(const JfConfig *cfg);
+
+/* Lists Jellyfin Live TV channels with each channel's current program.
+ * Results retain the server's order and are paginated like library items. */
+int jf_list_live_tv_channels(const JfConfig *cfg, int start_index,
+                              JfItem *out, int max, int64_t *total_out);
+
+/* Builds the request path used by jf_list_live_tv_channels. */
+void jf_build_live_tv_channels_path(const JfConfig *cfg, int start_index, int max,
+                                     char *path, size_t path_size);
 
 /* The BaseItemKind that actually represents "one unit" of a library, keyed
  * off CollectionType — used both for the carousel's "N movies/series/
@@ -468,6 +487,13 @@ typedef struct {
     int max_height;
     int video_bitrate;   /* bits/sec */
 } JfStreamProfile;
+
+typedef struct {
+    char live_stream_id[JF_LIVE_ID_LEN];
+    char media_source_id[JF_LIVE_ID_LEN];
+    char play_session_id[64];
+    char stream_url[JF_STREAM_URL_LEN];
+} JfLivePlayback;
 
 /* What the client asks the server to transcode down to, before mplayer scales
  * it back up (or down) to fill the framebuffer.
@@ -536,6 +562,39 @@ int jf_stream_url(const JfConfig *cfg, const char *item_id,
                    const char *play_session_id, int burn_in_sub_index,
                    int audio_stream_index,
                    char *out, int outlen);
+
+/* Opens a tuner-backed channel through Jellyfin's playback-info workflow.
+ * The result retains the negotiated URL and identifiers for playback session
+ * reporting. A stopped session report normally releases the live stream.
+ * jf_close_live_tv_stream is the cleanup fallback when reporting is not
+ * possible, such as an incomplete response or application shutdown. */
+int jf_open_live_tv_stream(const JfConfig *cfg, const char *channel_id,
+                            const JfStreamProfile *profile,
+                            JfLivePlayback *playback);
+int jf_build_live_tv_playback_info_body(const JfConfig *cfg,
+                                         const JfStreamProfile *profile,
+                                         char *out, int outlen);
+void jf_build_live_tv_playback_info_path(const char *channel_id,
+                                          char *path, size_t path_size);
+void jf_close_live_tv_stream(const JfConfig *cfg, const char *live_stream_id);
+/* Builds Jellyfin's playback-session payload. Pass failed=-1 for start and
+ * progress reports, where Failed is not part of the request. */
+int jf_build_live_tv_playstate_body(const JfLivePlayback *playback,
+                                     const char *item_id, int64_t position_ticks,
+                                     int paused, int failed,
+                                     char *out, int outlen);
+void jf_report_live_tv_start(const JfConfig *cfg, const JfLivePlayback *playback,
+                              const char *item_id);
+void jf_report_live_tv_progress(const JfConfig *cfg, const JfLivePlayback *playback,
+                                 const char *item_id, int64_t position_ticks);
+void jf_report_live_tv_stopped(const JfConfig *cfg, const JfLivePlayback *playback,
+                                const char *item_id, int64_t position_ticks,
+                                int failed);
+
+/* Resolves Jellyfin's negotiated transcode path against the configured server
+ * and adds URL authentication for mplayer. */
+int jf_live_tv_transcoding_url(const JfConfig *cfg, const char *transcoding_url,
+                                char *out, int outlen);
 
 /* Builds a direct-play audio stream URL (static=true — no server transcode:
  * confirmed against a real server that a plain FLAC/MP3 track streams back

--- a/src/main.c
+++ b/src/main.c
@@ -374,7 +374,8 @@ typedef enum {
 typedef enum {
     FRAME_VIEWS, FRAME_ITEMS, FRAME_SEASONS, FRAME_EPISODES,
     FRAME_RESUME,   /* Continue Watching — see JF_VIEW_RESUME */
-    FRAME_NEXTUP    /* Next Up          — see JF_VIEW_NEXTUP */
+    FRAME_NEXTUP,   /* Next Up          — see JF_VIEW_NEXTUP */
+    FRAME_LIVE_TV   /* Jellyfin Live TV channels */
 } FrameKind;
 
 /* Rows fetched for each home row. Both are "what to watch next" lists rather
@@ -715,12 +716,29 @@ static int fetch_frame_window(int start_index)
         }
 
         int n_views = jf_list_views(&g_cfg, g_items + n_synth, JF_MAX_ITEMS - n_synth);
+        int has_live_tv_view = 0;
         for (int i = 0; i < n_views; i++) {
             JfItem *v = &g_items[n_synth + i];
-            g_view_counts[n_synth + i] =
-                jf_count_items(&g_cfg, v->id, collection_item_type(v->collection_type));
+            if (view_is_live_tv(v)) {
+                has_live_tv_view = 1;
+                g_view_counts[n_synth + i] = -1;
+            } else {
+                g_view_counts[n_synth + i] =
+                    jf_count_items(&g_cfg, v->id, collection_item_type(v->collection_type));
+            }
         }
         g_item_count = n_synth + n_views;
+        if (!has_live_tv_view && g_item_count < JF_MAX_ITEMS && jf_live_tv_available(&g_cfg)) {
+            JfItem *card = &g_items[g_item_count];
+            memset(card, 0, sizeof(*card));
+            strncpy(card->id, JF_VIEW_LIVE_TV, sizeof(card->id) - 1);
+            strncpy(card->name, "Live TV", sizeof(card->name) - 1);
+            card->type = JF_TYPE_FOLDER;
+            card->synthetic = JF_SYNTH_LIVE_TV;
+            card->index_number = -1;
+            g_view_counts[g_item_count] = -1;
+            g_item_count++;
+        }
         break;
     }
     case FRAME_RESUME:
@@ -732,6 +750,13 @@ static int fetch_frame_window(int start_index)
         g_window_start = 0;
         g_item_count = jf_list_nextup(&g_cfg, g_items, HOME_ROW_MAX, &g_total_count);
         home_row_label_episodes();
+        break;
+    case FRAME_LIVE_TV:
+        /* Match Jellyfin Web's channel browser: preserve the order returned
+         * by /LiveTv/Channels and page through the complete result. */
+        paginated = 1;
+        g_item_count = jf_list_live_tv_channels(&g_cfg, start_index, g_items,
+                                                 JF_PAGE_SIZE, &g_total_count);
         break;
     case FRAME_ITEMS:
         /* Episode counts for series rows used to be fetched here with one
@@ -2241,7 +2266,9 @@ static void draw_browse(FBDev *fb)
         JfItem *it = &g_items[i];
 
         char line1[280];
-        if (it->year[0] &&
+        if (it->type == JF_TYPE_LIVE_CHANNEL && it->channel_number[0])
+            snprintf(line1, sizeof(line1), "%s  %s", it->channel_number, it->name);
+        else if (it->year[0] &&
             (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
              it->type == JF_TYPE_SERIES))
             snprintf(line1, sizeof(line1), "%s%s (%s)", type_folder_icon(it->type), it->name, it->year);
@@ -2256,7 +2283,10 @@ static void draw_browse(FBDev *fb)
          * and episode rows show runtime plus watched/resume state. */
         char line2[64] = {0};
         uint8_t l2r = 0x58, l2g = 0x58, l2b = 0x58;
-        if (it->type == JF_TYPE_ALBUM) {
+        if (it->type == JF_TYPE_LIVE_CHANNEL) {
+            snprintf(line2, sizeof(line2), "%s",
+                     it->current_program[0] ? it->current_program : "No guide information");
+        } else if (it->type == JF_TYPE_ALBUM) {
             if (it->year[0] && it->child_count > 0)
                 snprintf(line2, sizeof(line2), "%s - %d track%s",
                          it->year, it->child_count, it->child_count == 1 ? "" : "s");
@@ -2608,6 +2638,10 @@ static int     g_paused          = 0;
 static double  g_pause_wall      = 0.0;
 static char    g_play_session_id[64];
 static double  g_last_progress_report = 0.0;
+/* Live TV reuses the video process and transcode path, but it is not a
+ * seekable library item and must not acquire resume or watched state. */
+static int     g_live_playback = 0;
+static JfLivePlayback g_live;
 
 /* Playback progress is fire-and-forget (the result is never read), but the
  * curl round-trip is blocking — running it on the main thread froze the
@@ -2639,6 +2673,29 @@ static void report_progress_async(const char *item_id, const char *session,
     pthread_attr_init(&at);
     pthread_attr_setdetachstate(&at, PTHREAD_CREATE_DETACHED);
     if (pthread_create(&t, &at, progress_report_thread, j) != 0) free(j);
+    pthread_attr_destroy(&at);
+}
+typedef struct { char item_id[JF_ID_LEN]; JfLivePlayback playback; int64_t pos; } LiveProgressJob;
+static void *live_progress_report_thread(void *arg)
+{
+    LiveProgressJob *j = (LiveProgressJob *)arg;
+    jf_report_live_tv_progress(&g_cfg, &j->playback, j->item_id, j->pos);
+    free(j);
+    return NULL;
+}
+static void report_live_progress_async(const char *item_id,
+                                       const JfLivePlayback *playback,
+                                       int64_t pos)
+{
+    LiveProgressJob *j = malloc(sizeof(*j));
+    if (!j) return;
+    snprintf(j->item_id, sizeof(j->item_id), "%s", item_id);
+    j->playback = *playback;
+    j->pos = pos;
+    pthread_t t; pthread_attr_t at;
+    pthread_attr_init(&at);
+    pthread_attr_setdetachstate(&at, PTHREAD_CREATE_DETACHED);
+    if (pthread_create(&t, &at, live_progress_report_thread, j) != 0) free(j);
     pthread_attr_destroy(&at);
 }
 /* -1 = off, otherwise JfSubtitle.index of the loaded/active track. Text
@@ -2737,6 +2794,9 @@ static int player_running(void)
         if (waitpid(g_curl_pid, &cstatus, WNOHANG) > 0) {
             g_curl_pid = -1;
             if (!(WIFEXITED(cstatus) && WEXITSTATUS(cstatus) == 0)) {
+                jf_log_line("stream curl: exited=%d signal=%d",
+                            WIFEXITED(cstatus) ? WEXITSTATUS(cstatus) : -1,
+                            WIFSIGNALED(cstatus) ? WTERMSIG(cstatus) : 0);
                 /* curl died (bad TLS, DNS, connection refused, ...) — mplayer
                  * is left blocked opening/reading a FIFO with no writer left
                  * and would otherwise hang on it forever. Tear the whole
@@ -2753,7 +2813,13 @@ static int player_running(void)
         }
     }
     int status;
-    if (waitpid(g_player_pid, &status, WNOHANG) > 0) { g_player_pid = -1; return 0; }
+    if (waitpid(g_player_pid, &status, WNOHANG) > 0) {
+        jf_log_line("mplayer: exited=%d signal=%d",
+                    WIFEXITED(status) ? WEXITSTATUS(status) : -1,
+                    WIFSIGNALED(status) ? WTERMSIG(status) : 0);
+        g_player_pid = -1;
+        return 0;
+    }
     return 1;
 }
 
@@ -3764,6 +3830,35 @@ static void seek_accumulate(double delta, double now)
 #define PLAYER_FRAME_HANDLED 2
 static int player_handle_input(FBDev *fb, int inp, double loop_now)
 {
+    if (g_live_playback) {
+        if (!player_running()) {
+            double pos = play_position();
+            pageflip_end();
+            jf_report_live_tv_stopped(&g_cfg, &g_live, g_info_item.id,
+                                       (int64_t)(pos * 10000000.0), 1);
+            memset(&g_live, 0, sizeof(g_live));
+            g_live_playback = 0;
+            jf_log_line("live tv: stream ended");
+            return PLAYER_FRAME_ENDED;
+        }
+        if (inp & INP_B) {
+            double pos = play_position();
+            player_stop();
+            jf_report_live_tv_stopped(&g_cfg, &g_live, g_info_item.id,
+                                       (int64_t)(pos * 10000000.0), 0);
+            memset(&g_live, 0, sizeof(g_live));
+            g_live_playback = 0;
+            jf_log_line("live tv: stopped by user");
+            return PLAYER_FRAME_ENDED;
+        }
+        if (loop_now - g_last_progress_report >= PROGRESS_REPORT_INTERVAL) {
+            g_last_progress_report = loop_now;
+            report_live_progress_async(g_info_item.id, &g_live,
+                                       (int64_t)(play_position() * 10000000.0));
+        }
+        return PLAYER_FRAME_PLAYING;
+    }
+
     if (!player_running()) {
         /* mplayer exited on its own (end of title) — its uninit
          * already flipped back to page 0; this wakes Main up and
@@ -3859,16 +3954,30 @@ static void play(FBDev *fb, const char *item_id, double offset_secs)
     int64_t start_ticks = (int64_t)(offset_secs * 10000000.0);
     jf_make_play_session_id(g_play_session_id, sizeof(g_play_session_id));
 
-    char url[700];
+    char url[JF_STREAM_URL_LEN];
     const JfStreamProfile profile = stream_profile();
-    jf_stream_url(&g_cfg, item_id, &profile, start_ticks, g_play_session_id,
-                  g_burned_in_sub_index, g_current_audio_index, url, sizeof(url));
+    if (g_live_playback) {
+        if (!jf_open_live_tv_stream(&g_cfg, item_id, &profile, &g_live)) {
+            jf_log_line("live tv: failed to open stream");
+            return;
+        }
+        snprintf(g_play_session_id, sizeof(g_play_session_id), "%s",
+                 g_live.play_session_id);
+        snprintf(url, sizeof(url), "%s", g_live.stream_url);
+    } else {
+        jf_stream_url(&g_cfg, item_id, &profile, start_ticks, g_play_session_id,
+                      g_burned_in_sub_index, g_current_audio_index, url, sizeof(url));
+    }
     stream_via_curl_if_https(url, sizeof(url));
     /* Deliberately no item_id/title/url here — those identify what's in
      * someone's library, not how MiSTerFin behaved. */
-    jf_log_line("play: profile=%dx%d@%d fb_phys_h=%d line_double=%d resume=%.0fs",
-                profile.max_width, profile.max_height, profile.video_bitrate,
-                fb->phys_height, fb->line_double, offset_secs);
+    if (g_live_playback)
+        jf_log_line("live tv: opened stream fb_phys_h=%d line_double=%d",
+                    fb->phys_height, fb->line_double);
+    else
+        jf_log_line("play: profile=%dx%d@%d fb_phys_h=%d line_double=%d resume=%.0fs",
+                    profile.max_width, profile.max_height, profile.video_bitrate,
+                    fb->phys_height, fb->line_double, offset_secs);
 
     char delay_arg[16];
     snprintf(delay_arg, sizeof(delay_arg), "%.2f", AUDIO_DELAY_SEC);
@@ -3877,7 +3986,8 @@ static void play(FBDev *fb, const char *item_id, double offset_secs)
     g_play_start_wall = now_sec();
     g_paused          = 0;
     g_last_progress_report = now_sec();
-    jf_report_start(&g_cfg, item_id, g_play_session_id, start_ticks, "Transcode");
+    if (!g_live_playback)
+        jf_report_start(&g_cfg, item_id, g_play_session_id, start_ticks, "Transcode");
 
     /* Picture zoom survives restarts of the SAME title (that's exactly how
      * the PICTURE tab applies it — see submenu_confirm) but never carries
@@ -4208,7 +4318,12 @@ vf_done:;
                          ? "/media/fat/misterfin/font2x/font.desc"
                          : "/media/fat/misterfin/font/font.desc";
         args[an++] = "-framedrop";
-        args[an++] = "-autosync"; args[an++] = "30";
+        /* Live broadcasts can carry continuously corrected timestamps. Let
+         * mplayer react to the ALSA delay measurement on each frame instead
+         * of smoothing it across 30 samples, which can leave live video
+         * chasing a moving audio clock. Recorded playback keeps the existing
+         * smoothing that has proven stable with the MiSTer's ALSA driver. */
+        args[an++] = "-autosync"; args[an++] = g_live_playback ? "1" : "30";
         args[an++] = "-cache";    args[an++] = "8192";
         args[an++] = "-cache-min"; args[an++] = "20";
         /* mplayer's own native MPEG-TS demuxer sometimes misses the
@@ -4324,6 +4439,11 @@ vf_done:;
 
     close(pfd[0]);
     g_cmd_fd = pfd[1];
+    /* Jellyfin Web reports Live TV only after the player has started. Keep
+     * the same ordering by waiting until the mplayer child is launched.
+     * Recorded playback retains its existing report timing. */
+    if (g_live_playback)
+        jf_report_live_tv_start(&g_cfg, &g_live, item_id);
 
     /* mplayer is connecting + filling its cache in the background at this
      * point and hasn't touched /dev/fb0 yet — safe window to show the
@@ -5639,12 +5759,14 @@ int main(int argc, char **argv)
                 switch (it->type) {
                 case JF_TYPE_FOLDER:
                 case JF_TYPE_ARTIST:
-                    /* The two home rows look like folders but have no parent
-                     * to list — they're their own kind of frame. */
+                    /* Synthetic cards look like folders but have no parent
+                     * to list — each routes to its own frame kind. */
                     if (view_is_resume(it))
                         push_frame(FRAME_RESUME, "Continue Watching", NULL, NULL, NULL, NULL);
                     else if (view_is_nextup(it))
                         push_frame(FRAME_NEXTUP, "Next Up", NULL, NULL, NULL, NULL);
+                    else if (view_is_live_tv(it))
+                        push_frame(FRAME_LIVE_TV, "Live TV", NULL, NULL, NULL, NULL);
                     else
                         push_frame(FRAME_ITEMS, it->name, it->id, NULL, NULL,
                                    it->collection_type[0] ? it->collection_type : f->collection_type);
@@ -5684,6 +5806,17 @@ int main(int argc, char **argv)
                     play_audio(&fb, g_sel);
                     state = STATE_PLAYING_AUDIO;
                     draw_now_playing(&fb, &g_items[g_sel], 0.0);
+                    input_drain();
+                    break;
+                case JF_TYPE_LIVE_CHANNEL:
+                    g_info_item = *it;
+                    g_live_playback = 1;
+                    playing = 1;
+                    state = STATE_PLAYING;
+                    g_current_sub_index = -1;
+                    g_burned_in_sub_index = -1;
+                    g_current_audio_index = -1;
+                    play(&fb, g_info_item.id, 0.0);
                     input_drain();
                     break;
                 default:
@@ -5932,8 +6065,10 @@ int main(int argc, char **argv)
     bgm_resume();
     /* Before jf_log_close(): the mixer thread logs on its way out. */
     sfx_shutdown();
-    jf_log_close();
     player_stop();
+    if (g_live_playback)
+        jf_close_live_tv_stream(&g_cfg, g_live.live_stream_id);
+    jf_log_close();
     info_assets_free();
     ddr_close();
     cursor_show();

--- a/tests/test_jellyfin_queries.c
+++ b/tests/test_jellyfin_queries.c
@@ -1,9 +1,11 @@
-/* Unit tests for jf_build_items_path() — build and run with `make test`.
+/* Focused request-construction tests — build and run with `make test`.
  *
  * Item-list queries differ by collection type because Jellyfin can spend
  * enough time computing unused count fields to exceed MiSTerFin's request
  * timeout. Compare complete paths so changes to traversal, fields, sorting,
- * paging, user data, or image selection cannot pass unnoticed. */
+ * paging, user data, or image selection cannot pass unnoticed. Live TV tests
+ * also pin the Jellyfin Web-style PlaybackInfo body, playback session fields,
+ * URL authentication, and the narrow server compatibility workaround. */
 
 #include <stdio.h>
 #include <string.h>
@@ -18,6 +20,14 @@ static int checks;
         failures++;                                                   \
         printf("  FAIL %s\n    expected: %s\n    got:      %s\n",    \
                (label), (expected), (got));                           \
+    }                                                                 \
+} while (0)
+
+#define CHECK_TRUE(label, condition) do {                             \
+    checks++;                                                         \
+    if (!(condition)) {                                               \
+        failures++;                                                   \
+        printf("  FAIL %s\n", (label));                              \
     }                                                                 \
 } while (0)
 
@@ -102,6 +112,141 @@ static void test_standard_query(void)
     CHECK_PATH("missing type uses standard query", path, expected);
 }
 
+static void test_live_tv_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_live_tv_channels_path(&cfg, 9, 40, path, sizeof(path));
+
+    CHECK_PATH("Live TV channel query", path,
+        "/LiveTv/Channels?userId=user-id&StartIndex=9&Limit=40"
+        "&AddCurrentProgram=true"
+        "&EnableImages=true&ImageTypeLimit=1&EnableImageTypes=Primary");
+
+    jf_build_live_tv_channels_path(&cfg, -3, 1, path, sizeof(path));
+    CHECK_PATH("Live TV start index is normalized", path,
+        "/LiveTv/Channels?userId=user-id&StartIndex=0&Limit=1"
+        "&AddCurrentProgram=true"
+        "&EnableImages=true&ImageTypeLimit=1&EnableImageTypes=Primary");
+}
+
+static void test_live_tv_playback_paths(void)
+{
+    JfConfig cfg = config();
+    strcpy(cfg.server, "http://jellyfin");
+    strcpy(cfg.token, "test-token");
+    strcpy(cfg.device_id, "test-device");
+    strcpy(cfg.tv_mode, "NTSC");
+    char path[512];
+
+    jf_build_live_tv_playback_info_path("channel/id", path, sizeof(path));
+    CHECK_PATH("Live TV playback-info query", path,
+        "/Items/channel_id/PlaybackInfo");
+
+    JfStreamProfile profile = {640, 480, 5000000};
+    char body[1536];
+    CHECK_TRUE("Live TV playback-info body fits",
+          jf_build_live_tv_playback_info_body(&cfg, &profile, body, sizeof(body)));
+    CHECK_TRUE("Live TV profile identifies the user",
+          strstr(body, "\"UserId\":\"user-id\"") != NULL);
+    CHECK_TRUE("Live TV profile starts at the live edge",
+          strstr(body, "\"StartTimeTicks\":0") != NULL);
+    CHECK_TRUE("Live TV profile opens the stream for playback",
+          strstr(body, "\"IsPlayback\":true,\"AutoOpenLiveStream\":true") != NULL);
+    CHECK_TRUE("Live TV profile forces server transcoding",
+          strstr(body, "\"EnableDirectPlay\":false,\"EnableDirectStream\":false,"
+                       "\"EnableTranscoding\":true") != NULL);
+    CHECK_TRUE("Live TV profile disables stream copies",
+          strstr(body, "\"AllowVideoStreamCopy\":false,"
+                       "\"AllowAudioStreamCopy\":false") != NULL);
+    CHECK_TRUE("Live TV profile carries the streaming bitrate",
+          strstr(body, "\"MaxStreamingBitrate\":5000000") != NULL);
+    CHECK_TRUE("Live TV profile requests MPEG-TS",
+          strstr(body, "\"Container\":\"ts\"") != NULL);
+    CHECK_TRUE("Live TV profile requests MPEG-2 video",
+          strstr(body, "\"VideoCodec\":\"mpeg2video\"") != NULL);
+    CHECK_TRUE("Live TV profile omits unsupported MPEG-2 profile and level",
+          strstr(body, "\"Property\":\"VideoProfile\"") == NULL &&
+          strstr(body, "\"Property\":\"VideoLevel\"") == NULL);
+    CHECK_TRUE("Live TV profile requests MP3 audio",
+          strstr(body, "\"AudioCodec\":\"mp3\"") != NULL);
+    CHECK_TRUE("Live TV profile carries width limit",
+          strstr(body, "\"Property\":\"Width\",\"Value\":\"640\"") != NULL);
+    CHECK_TRUE("Live TV profile carries height limit",
+          strstr(body, "\"Property\":\"Height\",\"Value\":\"480\"") != NULL);
+    CHECK_TRUE("Live TV profile carries NTSC frame-rate limit",
+          strstr(body, "\"Property\":\"VideoFramerate\",\"Value\":\"30\"") != NULL);
+    char small_body[32];
+    CHECK_TRUE("Live TV profile reports a truncated destination",
+          !jf_build_live_tv_playback_info_body(&cfg, &profile,
+                                                small_body, sizeof(small_body)));
+
+    strcpy(cfg.tv_mode, "PAL");
+    CHECK_TRUE("Live TV PAL profile fits",
+          jf_build_live_tv_playback_info_body(&cfg, &profile, body, sizeof(body)));
+    CHECK_TRUE("Live TV profile carries PAL frame-rate limit",
+          strstr(body, "\"Property\":\"VideoFramerate\",\"Value\":\"25\"") != NULL);
+
+    JfLivePlayback playback = {0};
+    strcpy(playback.media_source_id, "media-source");
+    strcpy(playback.play_session_id, "play-session");
+    memset(playback.live_stream_id, 'a', 160);
+    playback.live_stream_id[160] = '\0';
+    CHECK_TRUE("Live TV playstate retains a long tuner composite ID",
+          jf_build_live_tv_playstate_body(&playback, "channel/id", 0, 0, -1,
+                                           body, sizeof(body)) &&
+          strstr(body, playback.live_stream_id) != NULL);
+    strcpy(playback.live_stream_id, "live-stream");
+    CHECK_TRUE("Live TV playstate body fits",
+          jf_build_live_tv_playstate_body(&playback, "channel/id", 123456, 0, 1,
+                                           body, sizeof(body)));
+    CHECK_PATH("Live TV playstate follows Jellyfin session reporting", body,
+        "{\"ItemId\":\"channel_id\",\"MediaSourceId\":\"media-source\","
+        "\"LiveStreamId\":\"live-stream\",\"PlaySessionId\":\"play-session\","
+        "\"PositionTicks\":123456,\"IsPaused\":false,\"PlayMethod\":\"Transcode\","
+        "\"CanSeek\":false,\"Failed\":true}");
+    CHECK_TRUE("Live TV progress body fits",
+          jf_build_live_tv_playstate_body(&playback, "channel/id", 42, 0, -1,
+                                           body, sizeof(body)));
+    CHECK_TRUE("Live TV progress omits stop-only Failed",
+          strstr(body, "\"Failed\"") == NULL);
+    JfLivePlayback incomplete = {0};
+    CHECK_TRUE("Live TV playstate rejects incomplete negotiation",
+          !jf_build_live_tv_playstate_body(&incomplete, "channel/id", 0, 0, -1,
+                                            body, sizeof(body)) && body[0] == '\0');
+
+    jf_live_tv_transcoding_url(&cfg,
+        "/Videos/channel-id/stream.ts?MediaSourceId=source&level=4"
+        "&mpeg2video-level=4&h264-level=41&LiveStreamId=live&ApiKey=test-token",
+        path, sizeof(path));
+    CHECK_PATH("Live TV transcode path retains server auth and omits MPEG-2 level", path,
+        "http://jellyfin/Videos/channel-id/stream.ts?MediaSourceId=source&h264-level=41"
+        "&LiveStreamId=live&ApiKey=test-token");
+
+    jf_live_tv_transcoding_url(&cfg,
+        "/Videos/channel-id/stream.ts?MediaSourceId=source",
+        path, sizeof(path));
+    CHECK_PATH("Live TV transcode adds auth when the server omits it", path,
+        "http://jellyfin/Videos/channel-id/stream.ts?MediaSourceId=source&ApiKey=test-token");
+
+    jf_live_tv_transcoding_url(&cfg, "/Videos/channel-id/stream.ts",
+                               path, sizeof(path));
+    CHECK_PATH("Live TV transcode adds the first query parameter", path,
+        "http://jellyfin/Videos/channel-id/stream.ts?ApiKey=test-token");
+
+    CHECK_TRUE("Live TV transcode rejects a foreign absolute URL",
+          !jf_live_tv_transcoding_url(&cfg,
+              "http://other-server/Videos/channel-id/stream.ts", path, sizeof(path)));
+    CHECK_TRUE("Live TV transcode rejects a missing destination",
+          !jf_live_tv_transcoding_url(&cfg,
+              "/Videos/channel-id/stream.ts", NULL, 0));
+    char short_path[16];
+    CHECK_TRUE("Live TV transcode reports a truncated destination",
+          !jf_live_tv_transcoding_url(&cfg,
+              "/Videos/channel-id/stream.ts", short_path, sizeof(short_path)));
+}
+
 static void test_input_normalization(void)
 {
     JfConfig cfg = config();
@@ -130,14 +275,35 @@ static void test_collection_item_types(void)
                collection_item_type("musicvideos"), "MusicVideo");
 }
 
+static void test_live_tv_view_classification(void)
+{
+    JfItem server_view = {0};
+    strcpy(server_view.collection_type, "livetv");
+    CHECK_PATH("server Live TV view is recognized",
+               view_is_live_tv(&server_view) ? "yes" : "no", "yes");
+
+    JfItem synthetic_view = {0};
+    synthetic_view.synthetic = JF_SYNTH_LIVE_TV;
+    CHECK_PATH("synthetic Live TV view is recognized",
+               view_is_live_tv(&synthetic_view) ? "yes" : "no", "yes");
+
+    JfItem movie_view = {0};
+    strcpy(movie_view.collection_type, "movies");
+    CHECK_PATH("movie view is not Live TV",
+               view_is_live_tv(&movie_view) ? "yes" : "no", "no");
+}
+
 int main(void)
 {
     test_movie_query();
     test_music_query();
     test_music_video_query();
     test_standard_query();
+    test_live_tv_query();
+    test_live_tv_playback_paths();
     test_input_normalization();
     test_collection_item_types();
+    test_live_tv_view_classification();
 
     printf("jellyfin queries: %d checks, %d failures\n", checks, failures);
     return failures ? 1 : 0;

--- a/tools/mock-jellyfin.py
+++ b/tools/mock-jellyfin.py
@@ -87,8 +87,8 @@ VIEWS = [
     {"Id": "view-movies", "Name": "Movies",   "CollectionType": "movies"},
     {"Id": "view-tv",     "Name": "TV Shows", "CollectionType": "tvshows"},
     {"Id": "view-music",  "Name": "Music",    "CollectionType": "music"},
+    {"Id": "view-live-tv", "Name": "Live TV", "CollectionType": "livetv"},
 ]
-
 
 def base_item(item_id, name, item_type, **extra):
     item = {
@@ -102,6 +102,19 @@ def base_item(item_id, name, item_type, **extra):
     }
     item.update(extra)
     return item
+
+
+LIVE_CHANNELS = [
+    base_item("channel-2-1", "WGBH", "TvChannel", Number="2.1",
+              CurrentProgram={"Name": "Nature", "StartDate": "2026-08-30T19:00:00Z",
+                              "EndDate": "2026-08-30T20:00:00Z"}),
+    base_item("channel-5-1", "WCVB", "TvChannel", Number="5.1",
+              CurrentProgram={"Name": "Evening News", "StartDate": "2026-08-30T19:30:00Z",
+                              "EndDate": "2026-08-30T20:00:00Z"}),
+    base_item("channel-7-1", "WHDH", "TvChannel", Number="7.1",
+              CurrentProgram={"Name": "Local Sports", "StartDate": "2026-08-30T19:00:00Z",
+                              "EndDate": "2026-08-30T21:00:00Z"}),
+]
 
 
 def build_library():
@@ -366,6 +379,13 @@ class Handler(BaseHTTPRequestHandler):
                                CollectionType=v["CollectionType"]) for v in VIEWS]
             return self._send({"Items": views, "TotalRecordCount": len(views)})
 
+        if path == "/LiveTv/Channels":
+            total = len(LIVE_CHANNELS)
+            start = int(query.get("StartIndex", [0])[0])
+            limit = int(query.get("Limit", [total])[0])
+            return self._send({"Items": LIVE_CHANNELS[start:start + limit],
+                               "TotalRecordCount": total, "StartIndex": start})
+
         if path == "/QuickConnect/Enabled":
             return self._send("true")
 
@@ -457,6 +477,54 @@ class Handler(BaseHTTPRequestHandler):
             return self._send({"AccessToken": "mock-access-token",
                                "ServerId": "mockserver",
                                "User": {"Id": USER_ID, "Name": USER_NAME}})
+
+        m = re.match(r"^/Items/([^/]+)/PlaybackInfo$", path)
+        if m:
+            if not self._authorized():
+                return self._send_401()
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length) or b"{}")
+            required = {
+                "UserId": USER_ID,
+                "StartTimeTicks": 0,
+                "IsPlayback": True,
+                "AutoOpenLiveStream": True,
+                "EnableDirectPlay": False,
+                "EnableDirectStream": False,
+                "EnableTranscoding": True,
+                "AllowVideoStreamCopy": False,
+                "AllowAudioStreamCopy": False,
+            }
+            if any(body.get(key) != value for key, value in required.items()):
+                return self._send({"Error": "invalid PlaybackInfo request"}, status=400)
+            profile = body.get("DeviceProfile", {})
+            transcodes = profile.get("TranscodingProfiles", [])
+            codec_profiles = profile.get("CodecProfiles", [])
+            conditions = codec_profiles[0].get("Conditions", []) if codec_profiles else []
+            properties = {condition.get("Property") for condition in conditions}
+            if (not transcodes or
+                    transcodes[0].get("Container") != "ts" or
+                    transcodes[0].get("VideoCodec") != "mpeg2video" or
+                    transcodes[0].get("AudioCodec") != "mp3" or
+                    profile.get("MaxStreamingBitrate") != body.get("MaxStreamingBitrate") or
+                    not {"Width", "Height", "VideoFramerate"} <= properties):
+                return self._send({"Error": "invalid device profile"}, status=400)
+            channel_id = m.group(1)
+            media_source_id = "native_" + "a" * 72
+            live_stream_id = "mock_" + "b" * 160
+            return self._send({
+                "MediaSources": [{
+                    "Id": media_source_id,
+                    "LiveStreamId": live_stream_id,
+                    "SupportsTranscoding": True,
+                    "TranscodingUrl": (
+                        f"/Videos/{channel_id}/stream.ts?MediaSourceId={media_source_id}"
+                        f"&mpeg2video-level=4&LiveStreamId={live_stream_id}"
+                        "&ApiKey=mock-api-key"
+                    ),
+                }],
+                "PlaySessionId": "mock-play-session",
+            })
 
         # Playback reporting / user data writes — accepted and ignored.
         length = int(self.headers.get("Content-Length", 0))


### PR DESCRIPTION
## Overview

Add Live TV channel browsing and playback through Jellyfin's standard Live TV and playback APIs.

MiSTerFin now discovers the authenticated user's channels, displays each channel's current program, negotiates a MiSTer-compatible transcode through Jellyfin's `PlaybackInfo` workflow, and reports the complete playback-session lifecycle.

The implementation is independent of Jellyfin's underlying Live TV provider. It has been tested with Jellyfin 10.11.11 and the built-in HDHomeRun integration.

## Implementation

- Discover channels through `/LiveTv/Channels`, preserving server order and pagination.
- Recognize a Jellyfin `livetv` root view or add a synthetic Live TV card when channels are available.
- Request playback using a posted `PlaybackInfo` body modeled on Jellyfin Web.
- Advertise MPEG-2 video, MP3 stereo audio, HTTP MPEG-TS, and the configured MiSTer transcode limits.
- Use Jellyfin's returned `TranscodingUrl` instead of constructing or falling back to a tuner-specific URL.
- Report playback start, progress, and stop with `ItemId`, `MediaSourceId`, `LiveStreamId`, and `PlaySessionId`.
- Avoid writing watched or resume state for live channels.
- Preserve existing movie, TV, music, and recorded-video behavior.
- Add focused unit and mock-server coverage for channel queries, playback negotiation, URL handling, long identifiers, and session payloads.

## Testing

- `make`: passed
- ARM cross-build: passed
- Jellyfin query tests: 46 checks, 0 failures
- Mock Live TV negotiation and lifecycle: passed
- Real Jellyfin 10.11.11 server with HDHomeRun: passed
- Real MiSTer hardware: HD and 480-line channels played successfully
- Final hardware request timings:
  - Channel listing: 182 ms
  - `PlaybackInfo`: 180 ms
  - Session start: 109 ms
  - Session progress: 231 ms
  - Session stopped: 2.807 seconds

Movie, TV, and large Music library browsing were also regression-tested successfully.

On this development workstation, `make test` reaches and passes the JSON, subtitle, configuration, and Jellyfin query suites, then stops at the pre-existing `test_sfx` assertion because the host has `libasound` while that test expects no mixer thread. The later hero and cache suites pass when run directly.

## Current limitations

Live TV currently provides channel browsing and playback. It does not yet provide a program-grid view, recordings, pause, seek, or track selection. Providers other than HDHomeRun should work through the same Jellyfin APIs but have not yet been verified.

## Relationship to Tunarr support

This change uses Jellyfin's provider-independent Live TV APIs. It does not add a direct Tunarr client or overlap with the Tunarr setup toolkit in #24. A Tunarr lineup exposed through Jellyfin should use this same playback path, while #24 also supports standalone Tunarr operation and a richer guide interface.
