### PR TITLE
Add Home Videos, Mixed libraries, and photo viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ All captured in-app via the [SELECT+START screenshot combo](#controls), straight
 
 ## <a id="scope"></a>Scope (v1)
 
-- Movies, TV shows, Music, and Music Videos — no photo libraries
+- Movies, TV shows, Music, and Music Videos
+- Home Videos preserves folder navigation; videos play and photos open in a fit-to-screen viewer
+- Mixed libraries preserve folders and expose video, music, and photo content; selecting an unsupported item type explains the limitation
 - Server-side transcode for video (the MiSTer's ARM Cortex-A9 can't decode arbitrary HEVC/4K sources locally) to a CRT-sized stream, then letterboxed/pillarboxed client-side to exactly fill the PAL/NTSC frame
 - Audio plays back directly (`static=true`, no server transcode) — this mplayer build decodes FLAC/MP3 natively, and there's no letterboxing concern for audio the way there is for video
 

--- a/src/jellyfin.c
+++ b/src/jellyfin.c
@@ -285,11 +285,14 @@ static void parse_item_fields(const JsonDoc *doc, const JsonNode *item, JfItem *
     else if (!strcmp(type_buf, "Episode"))       it->type = JF_TYPE_EPISODE;
     else if (!strcmp(type_buf, "Movie"))         it->type = JF_TYPE_MOVIE;
     else if (!strcmp(type_buf, "MusicVideo"))    it->type = JF_TYPE_MUSIC_VIDEO;
+    else if (!strcmp(type_buf, "Video"))         it->type = JF_TYPE_VIDEO;
+    else if (!strcmp(type_buf, "Photo"))         it->type = JF_TYPE_PHOTO;
     else if (!strcmp(type_buf, "MusicArtist"))   it->type = JF_TYPE_ARTIST;
     else if (!strcmp(type_buf, "MusicAlbum"))    it->type = JF_TYPE_ALBUM;
     else if (!strcmp(type_buf, "Audio"))         it->type = JF_TYPE_TRACK;
     else if (!strcmp(type_buf, "CollectionFolder") ||
-             !strcmp(type_buf, "Folder"))        it->type = JF_TYPE_FOLDER;
+             !strcmp(type_buf, "Folder") ||
+             !strcmp(type_buf, "PhotoAlbum"))    it->type = JF_TYPE_FOLDER;
     else                                          it->type = JF_TYPE_OTHER;
 
     if (it->type == JF_TYPE_TRACK) {
@@ -1204,7 +1207,15 @@ int jf_list_views(const JfConfig *cfg, JfItem *out, int max)
     JfResponse r;
     if (!jf_fetch(cfg, path, &r)) return 0;
     int n = parse_item_list(&r.doc, out, max);
-    for (int i = 0; i < n; i++) out[i].type = JF_TYPE_FOLDER;
+    for (int i = 0; i < n; i++) {
+        out[i].type = JF_TYPE_FOLDER;
+        /* Jellyfin stores Mixed as the absence of a collection type, while
+         * every other configurable library has an explicit value. Preserve
+         * that distinction so its item request can use the lightweight
+         * folder query instead of the count-bearing fallback. */
+        if (!out[i].collection_type[0])
+            strcpy(out[i].collection_type, "mixed");
+    }
     jf_response_free(&r);
     return n;
 }
@@ -1293,6 +1304,36 @@ void jf_build_items_path(const JfConfig *cfg, const char *parent_id,
             "/Items?userId=%s&ParentId=%s&SortBy=SortName&SortOrder=Ascending"
             "&Fields=ProductionYear,RunTimeTicks,ChildCount"
             "&EnableUserData=true"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
+    /* Home Videos preserves the user's folder and photo-album hierarchy, so
+     * list one level at a time and retain only the item types MiSTerFin can
+     * open. Jellyfin can spend several seconds loading user data for folder
+     * rows in a large photo library. Browse without it here; the single-item
+     * details request still fetches user data before a video is played. */
+    else if (collection_type && !strcmp(collection_type, "homevideos"))
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s&IncludeItemTypes=Folder,PhotoAlbum,Video,Photo"
+            "&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks"
+            "&EnableUserData=false"
+            "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=%d&Limit=%d",
+            cfg->user_id, safe_parent, start_index, max);
+    /* Mixed libraries retain their folder hierarchy and heterogeneous item
+     * types. Include every content-bearing type that can reasonably appear
+     * there, even when MiSTerFin cannot open it, so unsupported content stays
+     * visible and can report that limitation when selected. System folders,
+     * Live TV objects, and browse facets such as Genre are not library files
+     * and are deliberately excluded. As with Home Videos, omit folder user
+     * data to keep large hierarchical libraries responsive. */
+    else if (collection_type && !strcmp(collection_type, "mixed"))
+        snprintf(path, path_size,
+            "/Items?userId=%s&ParentId=%s"
+            "&IncludeItemTypes=Folder,PhotoAlbum,Movie,Series,Season,Episode,Video,MusicVideo,"
+            "Audio,MusicAlbum,MusicArtist,Photo,Book,AudioBook,BoxSet,Playlist,Trailer,Recording"
+            "&SortBy=SortName&SortOrder=Ascending"
+            "&Fields=ProductionYear,RunTimeTicks"
+            "&EnableUserData=false"
             "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=%d&Limit=%d",
             cfg->user_id, safe_parent, start_index, max);
     /* TV and other collection types keep the standard direct-child query.
@@ -1511,15 +1552,24 @@ int jf_item_image_url(const JfConfig *cfg, const char *item_id, const char *imag
     return 1;
 }
 
-int jf_download_item_image(const JfConfig *cfg, const char *item_id, const char *image_type,
-                            const char *tag, int max_width, const char *dest_path)
+int jf_photo_image_url(const JfConfig *cfg, const JfItem *item,
+                       int max_width, int max_height, char *out, int outlen)
 {
-    char url[512];
-    if (!jf_item_image_url(cfg, item_id, image_type, tag, max_width, url, sizeof(url))) return 0;
+    if (!item || !item->image_tag[0] || max_width <= 0 || max_height <= 0) return 0;
+    char safe_id[JF_ID_LEN], safe_tag[JF_ID_LEN];
+    jf_sanitize_id(item->id, safe_id, sizeof(safe_id));
+    jf_sanitize_id(item->image_tag, safe_tag, sizeof(safe_tag));
+    snprintf(out, outlen,
+             "%s/Items/%s/Images/Primary?tag=%s&maxWidth=%d&maxHeight=%d&quality=90&format=Jpg",
+             cfg->server, safe_id, safe_tag, max_width, max_height);
+    return 1;
+}
 
-    /* No shell — see jf_curl_run. The URL embeds an image tag that came
-     * from server JSON. -L follows redirects; TLS verification per config
-     * (see jf_add_tls_args). */
+static int jf_download_image_url(const JfConfig *cfg, const char *url,
+                                 const char *dest_path)
+{
+    /* No shell — see jf_curl_run. -L follows redirects; TLS verification per
+     * config (see jf_add_tls_args). */
     const char *argv[12];
     int n = 0;
     argv[n++] = "curl"; argv[n++] = "-sfL";
@@ -1530,6 +1580,23 @@ int jf_download_item_image(const JfConfig *cfg, const char *item_id, const char 
     int ok = 0;
     jf_curl_run((char *const *)argv, 0, &ok);
     return ok;
+}
+
+int jf_download_item_image(const JfConfig *cfg, const char *item_id, const char *image_type,
+                            const char *tag, int max_width, const char *dest_path)
+{
+    char url[512];
+    if (!jf_item_image_url(cfg, item_id, image_type, tag, max_width, url, sizeof(url))) return 0;
+
+    return jf_download_image_url(cfg, url, dest_path);
+}
+
+int jf_download_photo(const JfConfig *cfg, const JfItem *item,
+                      int max_width, int max_height, const char *dest_path)
+{
+    char url[512];
+    if (!jf_photo_image_url(cfg, item, max_width, max_height, url, sizeof(url))) return 0;
+    return jf_download_image_url(cfg, url, dest_path);
 }
 
 int jf_image_url(const JfConfig *cfg, const JfItem *item, char *out, int outlen)
@@ -1879,9 +1946,13 @@ int view_is_synthetic(const JfItem *v) { return v->synthetic != 0; }
 
 const char *collection_item_type(const char *collection_type)
 {
+    if (!collection_type) return NULL;
     if (!strcmp(collection_type, "movies"))      return "Movie";
     if (!strcmp(collection_type, "tvshows"))     return "Series";
     if (!strcmp(collection_type, "music"))       return "MusicAlbum";
     if (!strcmp(collection_type, "musicvideos")) return "MusicVideo";
+    if (!strcmp(collection_type, "homevideos"))  return "Video,Photo";
+    if (!strcmp(collection_type, "mixed"))
+        return "Movie,Series,Video,MusicVideo,Audio,Photo";
     return NULL;
 }

--- a/src/jellyfin.h
+++ b/src/jellyfin.h
@@ -42,6 +42,8 @@ typedef enum {
     JF_TYPE_EPISODE,
     JF_TYPE_MOVIE,
     JF_TYPE_MUSIC_VIDEO, /* MusicVideo — playable video leaf */
+    JF_TYPE_VIDEO,   /* generic Video — playable leaf in Home Videos */
+    JF_TYPE_PHOTO,   /* Photo — opens the still-image viewer */
     JF_TYPE_ARTIST,   /* MusicArtist — drills into albums, browsed like JF_TYPE_FOLDER */
     JF_TYPE_ALBUM,    /* MusicAlbum — drills into tracks, browsed like JF_TYPE_FOLDER */
     JF_TYPE_TRACK,    /* Audio — playable leaf, like JF_TYPE_MOVIE but audio-only */
@@ -415,13 +417,14 @@ int view_is_resume(const JfItem *v);
 int view_is_nextup(const JfItem *v);
 int view_is_synthetic(const JfItem *v);
 
-/* The BaseItemKind that actually represents "one unit" of a library, keyed
+/* The BaseItemKind values that represent the useful leaves of a library, keyed
  * off CollectionType — used both for the carousel's "N movies/series/
  * albums" count (jf_count_items) and its background cover grid
  * (jf_list_items_recursive): a plain direct-children listing of a by-artist
  * music library only finds MusicArtist folders, which often have no cover
  * art of their own, so both need to look past the top level at the real
- * leaf type. NULL (unrecognized collection type) means "don't filter". */
+ * leaf type. The result may be a comma-separated IncludeItemTypes value.
+ * NULL (unrecognized collection type) means "don't filter". */
 const char *collection_item_type(const char *collection_type);
 
 /* Partly-watched items across the whole library, most recently played first
@@ -462,6 +465,14 @@ int jf_item_image_url(const JfConfig *cfg, const char *item_id, const char *imag
                        const char *tag, int max_width, char *out, int outlen);
 int jf_download_item_image(const JfConfig *cfg, const char *item_id, const char *image_type,
                             const char *tag, int max_width, const char *dest_path);
+
+/* Photo viewer image. Both dimensions are capped server-side and JPEG is
+ * requested explicitly so the client never has to decode formats such as
+ * HEIC itself. */
+int jf_photo_image_url(const JfConfig *cfg, const JfItem *item,
+                       int max_width, int max_height, char *out, int outlen);
+int jf_download_photo(const JfConfig *cfg, const JfItem *item,
+                      int max_width, int max_height, const char *dest_path);
 
 typedef struct {
     int max_width;

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@
  * GRID_POSTER_TMP) for its own main-thread downloads — same thread, so
  * sharing is deliberate and safe; keep the two in sync. */
 #define POSTER_TMP   "/tmp/misterfin_poster.img"
+#define PHOTO_TMP    "/tmp/misterfin_photo.img"
 /* Per-item browse-list cover art, cached to the SD card (same idea as the
  * home-screen grid cache above) so scrolling a list reads covers from the
  * card instead of re-downloading each one — no network round-trip on the
@@ -369,7 +370,7 @@ static void fmt_time(char *buf, size_t sz, double secs)
 
 typedef enum {
     STATE_CONFIG_ERROR, STATE_QUICK_CONNECT,
-    STATE_BROWSE, STATE_INFO, STATE_PLAYING, STATE_PLAYING_AUDIO
+    STATE_BROWSE, STATE_INFO, STATE_PHOTO, STATE_PLAYING, STATE_PLAYING_AUDIO
 } AppState;
 typedef enum {
     FRAME_VIEWS, FRAME_ITEMS, FRAME_SEASONS, FRAME_EPISODES,
@@ -489,6 +490,12 @@ static const char *now_playing_mode_name(int mode)
 static double g_np_title_shown_until = 0.0;
 
 static JfItem g_info_item;   /* item currently shown on the info screen */
+static JfItem g_photo_item;  /* item currently shown in the photo viewer */
+static uint8_t *g_photo_px = NULL;
+static int      g_photo_w = 0, g_photo_h = 0;
+static int      g_photo_abs_index = 0;
+static char     g_photo_notice[64] = "";
+static double   g_photo_notice_until = 0.0;
 
 /* ── info-screen hero assets (backdrop, logo, cast photos) ───────────────── */
 
@@ -1563,9 +1570,11 @@ static const char *browse_cover_wanted_id(void)
     JfItem *it = (g_item_count > 0) ? &g_items[g_sel] : NULL;
     int wants = it && it->image_tag[0] &&
         (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+         it->type == JF_TYPE_VIDEO || it->type == JF_TYPE_PHOTO ||
          it->type == JF_TYPE_EPISODE ||
          it->type == JF_TYPE_SERIES || it->type == JF_TYPE_SEASON ||
-         it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM || it->type == JF_TYPE_TRACK);
+         it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM ||
+         it->type == JF_TYPE_TRACK);
     return wants ? it->id : "";
 }
 
@@ -1775,9 +1784,11 @@ static void start_cover_prefetch(void)
         JfItem *it = &g_items[i];
         int wants = it->image_tag[0] &&
             (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+             it->type == JF_TYPE_VIDEO || it->type == JF_TYPE_PHOTO ||
              it->type == JF_TYPE_EPISODE ||
              it->type == JF_TYPE_SERIES || it->type == JF_TYPE_SEASON ||
-             it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM || it->type == JF_TYPE_TRACK);
+             it->type == JF_TYPE_ARTIST || it->type == JF_TYPE_ALBUM ||
+             it->type == JF_TYPE_TRACK);
         if (!wants) continue;
         snprintf(cp->items[cp->n].id,     JF_ID_LEN, "%s", it->id);
         snprintf(cp->items[cp->n].img_id, JF_ID_LEN, "%s", it->image_item_id);
@@ -2243,6 +2254,7 @@ static void draw_browse(FBDev *fb)
         char line1[280];
         if (it->year[0] &&
             (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+             it->type == JF_TYPE_VIDEO ||
              it->type == JF_TYPE_SERIES))
             snprintf(line1, sizeof(line1), "%s%s (%s)", type_folder_icon(it->type), it->name, it->year);
         else
@@ -2286,6 +2298,7 @@ static void draw_browse(FBDev *fb)
                 snprintf(line2, sizeof(line2), "%d season%s",
                          it->child_count, it->child_count == 1 ? "" : "s");
         } else if (it->type == JF_TYPE_MOVIE || it->type == JF_TYPE_MUSIC_VIDEO ||
+                   it->type == JF_TYPE_VIDEO ||
                    it->type == JF_TYPE_EPISODE) {
             int minutes = (int)(it->runtime_ticks / 10000000LL / 60);
             if (it->played) {
@@ -2501,6 +2514,133 @@ static void draw_info(FBDev *fb)
               fb->height - 8 - SAFE_Y_BOT, hint, 1, COL_HINT);
 
     fb_flip(fb);
+}
+
+/* ── still-photo viewer ────────────────────────────────────────────────────
+ * Photos use Jellyfin's image endpoint rather than the media stream path.
+ * The server bounds and converts the source before download, so a large HEIC
+ * or camera JPEG never reaches this small device at its original dimensions
+ * and stb_image only has to handle an ordinary JPEG. */
+static void photo_free(void)
+{
+    if (g_photo_px) { stbi_image_free(g_photo_px); g_photo_px = NULL; }
+    g_photo_w = g_photo_h = 0;
+    unlink(PHOTO_TMP);
+}
+
+static void photo_notice(const char *text)
+{
+    snprintf(g_photo_notice, sizeof(g_photo_notice), "%s", text);
+    g_photo_notice_until = now_sec() + 1.5;
+}
+
+/* Loads first and swaps second, so a failed next/previous request leaves the
+ * current photo intact instead of replacing it with a blank screen. */
+static int photo_load(FBDev *fb, const JfItem *item, int *spinner_frame)
+{
+    unlink(PHOTO_TMP);
+    draw_spinner_frame(fb, (*spinner_frame)++);
+    fb_flip(fb);
+    if (!jf_download_photo(&g_cfg, item, fb->width, fb->height, PHOTO_TMP)) {
+        unlink(PHOTO_TMP);
+        return 0;
+    }
+
+    int w = 0, h = 0;
+    uint8_t *px = load_image_tmp(PHOTO_TMP, &w, &h);
+    if (!px || w <= 0 || h <= 0) {
+        if (px) stbi_image_free(px);
+        return 0;
+    }
+
+    if (g_photo_px) stbi_image_free(g_photo_px);
+    g_photo_px = px;
+    g_photo_w = w;
+    g_photo_h = h;
+    g_photo_item = *item;
+    g_photo_abs_index = g_window_start + g_sel;
+    g_photo_notice[0] = '\0';
+    g_photo_notice_until = 0.0;
+    return 1;
+}
+
+static void draw_photo(FBDev *fb)
+{
+    fb_clear(fb);
+    if (g_photo_px)
+        blit_fit_centered(fb, g_photo_px, g_photo_w, g_photo_h,
+                          fb->width / 2, fb->height / 2,
+                          fb->width, fb->height, 255);
+
+    /* Keep controls legible over both dark and bright photos. The image still
+     * occupies the full frame; these are overlays, not reserved letterbox
+     * bands that would shrink it. */
+    int top_h = SAFE_Y + 12;
+    int bottom_y = fb->height - SAFE_Y_BOT - 12;
+    fb_fill_rect_alpha(fb, 0, 0, fb->width, top_h, 0, 0, 0, 175);
+    fb_fill_rect_alpha(fb, 0, bottom_y, fb->width, fb->height - bottom_y,
+                       0, 0, 0, 175);
+
+    char counter[32];
+    int64_t total = g_total_count > 0 ? g_total_count : g_item_count;
+    snprintf(counter, sizeof(counter), "%d/%lld",
+             g_photo_abs_index + 1, (long long)total);
+    int counter_w = text_width(fb, counter, 1);
+    char title[JF_NAME_LEN];
+    snprintf(title, sizeof(title), "%s", g_photo_item.name);
+    truncate_to_width(fb, title, 1, fb->width - 2 * SAFE_X - counter_w - 12);
+    draw_text(fb, SAFE_X, SAFE_Y, title, 1, COL_SEL_FG);
+    draw_text(fb, fb->width - SAFE_X - counter_w, SAFE_Y, counter, 1, COL_HINT);
+
+    const char *hint = "LEFT/RIGHT: browse photos   A:back";
+    draw_text(fb, (fb->width - text_width(fb, hint, 1)) / 2,
+              fb->height - 8 - SAFE_Y_BOT, hint, 1, COL_HINT);
+
+    if (g_photo_notice[0] && now_sec() < g_photo_notice_until) {
+        int tw = text_width(fb, g_photo_notice, 1);
+        int x = (fb->width - tw) / 2;
+        int y = fb->height / 2 - 4;
+        fb_fill_rect_alpha(fb, x - 8, y - 6, tw + 16, 20, 0, 0, 0, 210);
+        draw_text(fb, x, y, g_photo_notice, 1, COL_SEL_FG);
+    }
+
+    fb_flip(fb);
+}
+
+/* Finds the next Photo row in absolute list order. browse_move_sel already
+ * owns page-boundary fetching, clamping, and scroll positioning, so the
+ * viewer reuses it rather than maintaining a second pagination model. */
+static int photo_move(FBDev *fb, int direction, int *spinner_frame)
+{
+    int original_abs = g_window_start + g_sel;
+    int original_window = g_window_start;
+
+    while (browse_move_sel(fb, direction)) {
+        if (g_items[g_sel].type != JF_TYPE_PHOTO) continue;
+        if (photo_load(fb, &g_items[g_sel], spinner_frame)) {
+            if (g_window_start != original_window) {
+                g_cover_gen++;
+                start_cover_prefetch();
+            }
+            return 1;
+        }
+
+        browse_move_sel(fb, original_abs - (g_window_start + g_sel));
+        if (g_window_start != original_window) {
+            g_cover_gen++;
+            start_cover_prefetch();
+        }
+        photo_notice("Photo unavailable");
+        return 0;
+    }
+
+    browse_move_sel(fb, original_abs - (g_window_start + g_sel));
+    if (g_window_start != original_window) {
+        g_cover_gen++;
+        start_cover_prefetch();
+    }
+    photo_notice(direction > 0 ? "No later photos" : "No earlier photos");
+    return 0;
 }
 
 /* Simple dashed track + a small square marker at the current position,
@@ -4920,6 +5060,7 @@ static void redraw_current_screen(FBDev *fb, AppState state)
     switch (state) {
     case STATE_BROWSE:       draw_browse(fb); break;
     case STATE_INFO:         draw_info(fb); break;
+    case STATE_PHOTO:        draw_photo(fb); break;
     case STATE_PLAYING_AUDIO: draw_now_playing(fb, &g_items[g_audio_queue_pos], play_position()); break;
     default: break;
     }
@@ -5674,10 +5815,21 @@ int main(int argc, char **argv)
                 }
                 case JF_TYPE_MOVIE:
                 case JF_TYPE_MUSIC_VIDEO:
+                case JF_TYPE_VIDEO:
                 case JF_TYPE_EPISODE:
                     info_assets_load(&fb, it, &spinner_frame_ctr);
                     state = STATE_INFO;
                     draw_info(&fb);
+                    input_drain();
+                    break;
+                case JF_TYPE_PHOTO:
+                    if (photo_load(&fb, it, &spinner_frame_ctr)) {
+                        state = STATE_PHOTO;
+                        draw_photo(&fb);
+                    } else {
+                        banner_enqueue("Photo unavailable");
+                        draw_browse(&fb);
+                    }
                     input_drain();
                     break;
                 case JF_TYPE_TRACK:
@@ -5687,6 +5839,8 @@ int main(int argc, char **argv)
                     input_drain();
                     break;
                 default:
+                    banner_enqueue("Item type not supported");
+                    input_drain();
                     break;
                 }
             }
@@ -5746,6 +5900,22 @@ int main(int argc, char **argv)
                 g_current_audio_index = default_audio_index();
                 play(&fb, g_info_item.id, 0.0);
                 input_drain();
+            }
+            break;
+
+        case STATE_PHOTO:
+            if (inp & INP_B) {
+                photo_free();
+                g_sel_anim = -1.0;
+                state = STATE_BROWSE;
+                draw_browse(&fb);
+                input_drain();
+            } else {
+                if (inp & (INP_LEFT | INP_UP))
+                    photo_move(&fb, -1, &spinner_frame_ctr);
+                else if (inp & (INP_RIGHT | INP_DOWN))
+                    photo_move(&fb, 1, &spinner_frame_ctr);
+                draw_photo(&fb);
             }
             break;
 
@@ -5935,6 +6105,7 @@ int main(int argc, char **argv)
     jf_log_close();
     player_stop();
     info_assets_free();
+    photo_free();
     ddr_close();
     cursor_show();
     /* Blanking on the way out leaves the MiSTer showing an empty screen

--- a/tests/test_jellyfin_queries.c
+++ b/tests/test_jellyfin_queries.c
@@ -1,4 +1,4 @@
-/* Unit tests for jf_build_items_path() — build and run with `make test`.
+/* Unit tests for Jellyfin item and image query builders — run with `make test`.
  *
  * Item-list queries differ by collection type because Jellyfin can spend
  * enough time computing unused count fields to exceed MiSTerFin's request
@@ -18,6 +18,26 @@ static int checks;
         failures++;                                                   \
         printf("  FAIL %s\n    expected: %s\n    got:      %s\n",    \
                (label), (expected), (got));                           \
+    }                                                                 \
+} while (0)
+
+#define CHECK_NULL(label, got) do {                                   \
+    const char *value = (got);                                        \
+    checks++;                                                         \
+    if (value != NULL) {                                              \
+        failures++;                                                   \
+        printf("  FAIL %s\n    expected: NULL\n    got:      %s\n",  \
+               (label), value);                                      \
+    }                                                                 \
+} while (0)
+
+#define CHECK_INT(label, got, expected) do {                          \
+    int value = (got);                                                \
+    checks++;                                                         \
+    if (value != (expected)) {                                        \
+        failures++;                                                   \
+        printf("  FAIL %s\n    expected: %d\n    got:      %d\n",  \
+               (label), (expected), value);                           \
     }                                                                 \
 } while (0)
 
@@ -78,6 +98,41 @@ static void test_music_video_query(void)
         "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=7&Limit=50");
 }
 
+static void test_home_video_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "home-video-view", "homevideos", 3, 40,
+                        path, sizeof(path));
+
+    CHECK_PATH("home-video query", path,
+        "/Items?userId=user-id&ParentId=home-video-view"
+        "&IncludeItemTypes=Folder,PhotoAlbum,Video,Photo"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks"
+        "&EnableUserData=false"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=3&Limit=40");
+}
+
+static void test_mixed_query(void)
+{
+    JfConfig cfg = config();
+    char path[512];
+
+    jf_build_items_path(&cfg, "mixed-view", "mixed", 6, 48,
+                        path, sizeof(path));
+
+    CHECK_PATH("mixed query", path,
+        "/Items?userId=user-id&ParentId=mixed-view"
+        "&IncludeItemTypes=Folder,PhotoAlbum,Movie,Series,Season,Episode,Video,MusicVideo,"
+        "Audio,MusicAlbum,MusicArtist,Photo,Book,AudioBook,BoxSet,Playlist,Trailer,Recording"
+        "&SortBy=SortName&SortOrder=Ascending"
+        "&Fields=ProductionYear,RunTimeTicks"
+        "&EnableUserData=false"
+        "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=6&Limit=48");
+}
+
 static void test_standard_query(void)
 {
     JfConfig cfg = config();
@@ -93,7 +148,7 @@ static void test_standard_query(void)
                         path, sizeof(path));
     CHECK_PATH("TV uses standard query", path, expected);
 
-    jf_build_items_path(&cfg, "tv-view", "books", 0, 128,
+    jf_build_items_path(&cfg, "tv-view", "plugin-defined", 0, 128,
                         path, sizeof(path));
     CHECK_PATH("unknown type uses standard query", path, expected);
 
@@ -118,6 +173,29 @@ static void test_input_normalization(void)
         "&ImageTypeLimit=1&EnableImageTypes=Primary,Backdrop&StartIndex=0&Limit=9");
 }
 
+static void test_photo_image_query(void)
+{
+    JfConfig cfg = config();
+    JfItem item = {0};
+    char url[512] = "";
+    strcpy(cfg.server, "http://jellyfin.test");
+    strcpy(item.id, "photo/id?");
+    strcpy(item.image_tag, "tag&value");
+
+    CHECK_INT("photo image URL is available",
+              jf_photo_image_url(&cfg, &item, 640, 288, url, sizeof(url)), 1);
+    CHECK_PATH("photo image query", url,
+        "http://jellyfin.test/Items/photo_id_/Images/Primary"
+        "?tag=tag_value&maxWidth=640&maxHeight=288&quality=90&format=Jpg");
+
+    item.image_tag[0] = '\0';
+    CHECK_INT("photo without an image tag is rejected",
+              jf_photo_image_url(&cfg, &item, 640, 288, url, sizeof(url)), 0);
+    strcpy(item.image_tag, "tag");
+    CHECK_INT("photo without bounded dimensions is rejected",
+              jf_photo_image_url(&cfg, &item, 640, 0, url, sizeof(url)), 0);
+}
+
 static void test_collection_item_types(void)
 {
     CHECK_PATH("movie collection item type",
@@ -128,6 +206,14 @@ static void test_collection_item_types(void)
                collection_item_type("music"), "MusicAlbum");
     CHECK_PATH("music-video collection item type",
                collection_item_type("musicvideos"), "MusicVideo");
+    CHECK_PATH("home-video collection item types",
+               collection_item_type("homevideos"), "Video,Photo");
+    CHECK_PATH("mixed collection item types",
+               collection_item_type("mixed"),
+               "Movie,Series,Video,MusicVideo,Audio,Photo");
+    CHECK_NULL("unknown collection item type",
+               collection_item_type("plugin-defined"));
+    CHECK_NULL("missing collection item type", collection_item_type(NULL));
 }
 
 int main(void)
@@ -135,8 +221,11 @@ int main(void)
     test_movie_query();
     test_music_query();
     test_music_video_query();
+    test_home_video_query();
+    test_mixed_query();
     test_standard_query();
     test_input_normalization();
+    test_photo_image_query();
     test_collection_item_types();
 
     printf("jellyfin queries: %d checks, %d failures\n", checks, failures);

--- a/tools/mock-jellyfin.py
+++ b/tools/mock-jellyfin.py
@@ -6,7 +6,9 @@ Serves just enough of the API for the client to browse, page, and
 authenticate against, backed by a synthetic library that is deliberately
 bigger than any fixed client-side buffer — 500 movies, so pagination has
 something real to page through, which a small personal library wouldn't
-exercise.
+exercise. It also includes a small Home Videos library with landscape and
+portrait photos for exercising the still-image viewer, plus a Mixed library
+with supported and unsupported item types.
 
 Stdlib only (http.server + zlib for the placeholder cover art). No
 dependencies, and nothing here talks to a real server or real credentials.
@@ -83,10 +85,24 @@ def _png(r, g, b, w=8, h=8):
 COVERS = [_png(200, 60, 60), _png(60, 160, 200), _png(200, 170, 60),
           _png(120, 90, 200), _png(70, 190, 120)]
 
+# The mock cannot transcode to the requested JPEG without an image library,
+# but serving PNG here still exercises download, decoding, and fit-to-screen
+# geometry. Distinct aspect ratios make accidental stretching easy to spot.
+PHOTO_IMAGES = {
+    "photo-landscape": _png(35, 125, 215, 16, 9),
+    "photo-portrait": _png(215, 95, 45, 9, 16),
+    "photo-album-item": _png(80, 185, 95, 4, 3),
+}
+
 VIEWS = [
     {"Id": "view-movies", "Name": "Movies",   "CollectionType": "movies"},
     {"Id": "view-tv",     "Name": "TV Shows", "CollectionType": "tvshows"},
     {"Id": "view-music",  "Name": "Music",    "CollectionType": "music"},
+    {"Id": "view-homevideos", "Name": "Home Videos",
+     "CollectionType": "homevideos"},
+    # Jellyfin represents a configured Mixed library by omitting
+    # CollectionType rather than returning the literal value "mixed".
+    {"Id": "view-mixed", "Name": "Mixed"},
 ]
 
 
@@ -213,6 +229,27 @@ def build_library():
             children[alid] = track_ids
         children[aid] = album_ids
     children["view-music"] = artist_ids
+
+    home_video = "home-video-1"
+    items[home_video] = base_item(
+        home_video, "Home Movie", "Video", ProductionYear=2025,
+        RunTimeTicks=8 * TICKS_PER_MIN)
+    items["photo-landscape"] = base_item(
+        "photo-landscape", "Landscape Photo", "Photo")
+    items["photo-portrait"] = base_item(
+        "photo-portrait", "Portrait Photo", "Photo")
+    items["photo-album"] = base_item(
+        "photo-album", "Photo Album", "PhotoAlbum", ChildCount=1)
+    items["photo-album-item"] = base_item(
+        "photo-album-item", "Album Photo", "Photo")
+    items["unsupported-book"] = base_item(
+        "unsupported-book", "Unsupported Book", "Book")
+    children["photo-album"] = ["photo-album-item"]
+    children["view-homevideos"] = [
+        home_video, "photo-landscape", "photo-album", "photo-portrait"]
+    children["view-mixed"] = [
+        movies[0], series_ids[0], home_video, "photo-landscape", artist_ids[0],
+        "unsupported-book"]
 
     return items, children
 
@@ -362,8 +399,12 @@ class Handler(BaseHTTPRequestHandler):
             return self._send([{"Id": USER_ID, "Name": USER_NAME}])
 
         if path == "/UserViews":
-            views = [base_item(v["Id"], v["Name"], "CollectionFolder",
-                               CollectionType=v["CollectionType"]) for v in VIEWS]
+            views = []
+            for view in VIEWS:
+                item = base_item(view["Id"], view["Name"], "CollectionFolder")
+                if "CollectionType" in view:
+                    item["CollectionType"] = view["CollectionType"]
+                views.append(item)
             return self._send({"Items": views, "TotalRecordCount": len(views)})
 
         if path == "/QuickConnect/Enabled":
@@ -383,7 +424,10 @@ class Handler(BaseHTTPRequestHandler):
 
         m = re.match(r"^/Items/([^/]+)/Images/([^/?]+)", path)
         if m:
-            return self._send(COVERS[hash(m.group(1)) % len(COVERS)], "image/png")
+            item_id = m.group(1)
+            image = PHOTO_IMAGES.get(item_id,
+                                     COVERS[hash(item_id) % len(COVERS)])
+            return self._send(image, "image/png")
 
         m = re.match(r"^/Shows/([^/]+)/Seasons$", path)
         if m:
@@ -478,5 +522,6 @@ if __name__ == "__main__":
         if arg.isdigit():
             port = int(arg)
     print(f"mock jellyfin on http://127.0.0.1:{port}  "
-          f"({N_MOVIES} movies, {N_SERIES} series, {N_ARTISTS} artists)")
+          f"({N_MOVIES} movies, {N_SERIES} series, {N_ARTISTS} artists, "
+          "2 top-level photos)")
     HTTPServer(("127.0.0.1", port), Handler).serve_forever()


### PR DESCRIPTION
## Overview

Large Jellyfin Home Videos and Photos libraries can exceed MiSTerFin's fixed request timeout when the standard item query asks Jellyfin to populate user data for folder rows. MiSTerFin also treated a missing library `CollectionType` as an unknown type, even though Jellyfin represents Mixed libraries by omitting that property. Finally, generic videos and photos had no complete browse/view path.

This change adds hierarchy-preserving Home Videos and Mixed-library browsing, generic video playback, and a still-photo viewer.

## Changes

- Preserve Jellyfin's missing `CollectionType` as `mixed` when library views are parsed.
- Give Home Videos a direct-child query for `Folder`, `PhotoAlbum`, `Video`, and `Photo`.
- Give Mixed libraries an explicit direct-child filter covering supported media and known unsupported content-bearing types.
- Omit count fields and set `EnableUserData=false` for these hierarchical queries. Item details still retrieve user data before video playback.
- Parse `Video` and `Photo`, and treat `PhotoAlbum` as a navigable folder.
- Play generic videos through the existing video information and playback path.
- Download photos through Jellyfin's image endpoint as server-bounded JPEGs and display them without stretching.
- Support previous/next photo navigation across paginated lists while preserving the current photo if another download fails.
- Keep unsupported Mixed-library items visible and show `Item type not supported` when selected.
- Extend the mock Jellyfin server and focused query tests for Home Videos, Mixed libraries, photos, missing `CollectionType`, music containers, and unsupported items.
- Update the documented v1 scope.

## Performance

Against Jellyfin 10.11.11, the final Home Videos root query returned 35 direct children, including 31 folders and 4 photos, in 0.307 seconds. The equivalent folder query with user data enabled exceeded MiSTerFin's timeout at about 8.03 seconds.

## Validation

- Host build passed.
- ARM build passed.
- Jellyfin query tests: 21 checks, 0 failures.
- JSON tests: 63 checks, 0 failures.
- Subtitle tests: 22 checks, 0 failures.
- Configuration tests: 14 checks, 0 failures.
- Hero tests: 3,134 checks, 0 failures.
- Cache sweep tests: 21 checks, 0 failures.
- Mock Mixed-library fallback, music-container parsing, unsupported-item parsing, and unsupported-item UI feedback passed.
- Home Videos folder navigation, video playback, and photo viewing were tested on a real MiSTer.

`make test` reaches the existing `test_sfx` host assertion on my development machine, which has `libasound` available while the test expects the no-`libasound` path. The tests before it pass, and the hero and cache tests after it pass when run directly.
