### PR TITLE
Hide pause controls until navigation input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRCS = src/main.c src/fb.c src/ddr.c src/grid.c src/visualizers.c src/jellyfin.c src/json.c src/session.c src/subtitles.c src/update.c src/input.c src/util.c src/draw.c src/screenshot.c src/sfx.c
+SRCS = src/main.c src/fb.c src/ddr.c src/grid.c src/visualizers.c src/jellyfin.c src/json.c src/session.c src/subtitles.c src/update.c src/input.c src/util.c src/draw.c src/screenshot.c src/sfx.c src/pause_ui.c
 
 TARGET     = misterfin
 TARGET_ARM = misterfin-arm
@@ -45,6 +45,8 @@ test:
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_jellyfin_queries \
 		tests/test_jellyfin_queries.c src/jellyfin.c src/json.c
 	@/tmp/misterfin_test_jellyfin_queries
+	$(CC) $(CFLAGS) -o /tmp/misterfin_test_pause_ui tests/test_pause_ui.c src/pause_ui.c
+	@/tmp/misterfin_test_pause_ui
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_sfx tests/test_sfx.c -lpthread
 	@/tmp/misterfin_test_sfx
 	$(CC) $(CFLAGS) -o /tmp/misterfin_test_hero tests/test_hero.c src/draw.c

--- a/src/main.c
+++ b/src/main.c
@@ -43,6 +43,7 @@
 #include "grid.h"
 #include "visualizers.h"
 #include "session.h"
+#include "pause_ui.h"
 
 #define MPLAYER      "/media/fat/misterfin/mplayer-arm"
 /* See stream_via_curl_if_https — only one stream (video or music, never
@@ -2535,9 +2536,43 @@ static void draw_timeline(FBDev *fb, int y, double pos, double duration)
 
 static JfStreamProfile stream_profile(void);   /* forward decl — defined with the playback code */
 
+static PauseUi  g_pause_ui;
+static uint8_t *g_pause_frame;
+static size_t   g_pause_frame_size;
+static int      g_pause_frame_current;
+
+/* Capture the undecorated paused video once, then compose every pause UI
+ * frame from that copy. fb_flip() writes overlays into the framebuffer, so
+ * syncing from the screen again after the first draw would permanently fold
+ * the overlay into its own background and leave nothing clean to restore. */
+static int pause_frame_capture(FBDev *fb)
+{
+    size_t size = (size_t)fb->stride * fb->height;
+    g_pause_frame_current = 0;
+    fb_sync_back(fb);
+    if (g_pause_frame_size != size) {
+        uint8_t *frame = realloc(g_pause_frame, size);
+        if (!frame) return 0;
+        g_pause_frame = frame;
+        g_pause_frame_size = size;
+    }
+    memcpy(g_pause_frame, fb->back, size);
+    g_pause_frame_current = 1;
+    return 1;
+}
+
+static int pause_frame_restore(FBDev *fb)
+{
+    size_t size = (size_t)fb->stride * fb->height;
+    if (!g_pause_frame_current || !g_pause_frame ||
+        g_pause_frame_size != size) return 0;
+    memcpy(fb->back, g_pause_frame, size);
+    return 1;
+}
+
 static void draw_paused(FBDev *fb, const char *name, double pos)
 {
-    fb_sync_back(fb);
+    if (!pause_frame_restore(fb)) fb_sync_back(fb);
 
     int cy = fb->height / 2 - 16;
     fb_fill_rect_alpha(fb, 0, cy - 6, fb->width, 50, 0, 0, 0, 200);
@@ -2591,6 +2626,27 @@ static void draw_paused(FBDev *fb, const char *name, double pos)
               fb->height - 8 - SAFE_Y_BOT, hint, 1, COL_HINT);
 
     fb_flip(fb);
+}
+
+/* Keep presenting the saved frame while paused even when the controls are
+ * hidden. This preserves the existing page-flip self-healing and lets the
+ * global message banner animate over an otherwise clean pause screen. */
+static void draw_clean_paused(FBDev *fb)
+{
+    if (!pause_frame_restore(fb)) fb_sync_back(fb);
+    fb_flip(fb);
+}
+
+static void pause_screen_begin(FBDev *fb)
+{
+    pause_ui_hide(&g_pause_ui);
+    (void)pause_frame_capture(fb);
+}
+
+static int pause_screen_reveal(FBDev *fb, double now)
+{
+    if (!g_pause_frame_current && !pause_frame_capture(fb)) return 0;
+    return pause_ui_reveal(&g_pause_ui, now);
 }
 
 /* ── playback (mplayer slave-mode) ───────────────────────────────────────── */
@@ -3789,9 +3845,16 @@ static int player_handle_input(FBDev *fb, int inp, double loop_now)
         return PLAYER_FRAME_ENDED;
     } else if (g_paused) {
         if (inp & INP_SELECT) { submenu_open(fb); draw_submenu(fb); input_drain(); return PLAYER_FRAME_HANDLED; }
-        if (inp & INP_LEFT)  seek_accumulate(-SEEK_STEP, loop_now);
-        if (inp & INP_RIGHT) seek_accumulate(+SEEK_STEP, loop_now);
-        if (inp & INP_A) player_pause_toggle();
+        int woke_controls = 0;
+        if (inp & (INP_UP | INP_DOWN | INP_LEFT | INP_RIGHT))
+            woke_controls = pause_screen_reveal(fb, loop_now);
+        if (!woke_controls && (inp & INP_LEFT))  seek_accumulate(-SEEK_STEP, loop_now);
+        if (!woke_controls && (inp & INP_RIGHT)) seek_accumulate(+SEEK_STEP, loop_now);
+        if (inp & INP_A) {
+            if (g_pause_ui.visible) draw_clean_paused(fb);
+            pause_ui_hide(&g_pause_ui);
+            player_pause_toggle();
+        }
         if (!g_pageflip_mode) {
             if (inp & INP_L) {
                 int vf = open(VSYNC_FLAG, O_WRONLY|O_CREAT|O_TRUNC, 0644);
@@ -3803,14 +3866,25 @@ static int player_handle_input(FBDev *fb, int inp, double loop_now)
                 osd_flash("VSync: OFF", 1);
             }
         }
-        /* seek_pending_target() reflects any not-yet-fired
-         * accumulated seek too, so this timeline moves live as the
-         * user taps LEFT/RIGHT instead of waiting for the debounce
-         * to actually fire the restart. */
-        draw_paused(fb, g_info_item.name, seek_pending_target());
+        if (g_paused) {
+            if (pause_ui_expire(&g_pause_ui, loop_now)) {
+                draw_clean_paused(fb);
+            } else if (g_pause_ui.visible) {
+                /* seek_pending_target() reflects any not-yet-fired
+                 * accumulated seek too, so this timeline moves live as the
+                 * user taps LEFT/RIGHT instead of waiting for the debounce
+                 * to actually fire the restart. */
+                draw_paused(fb, g_info_item.name, seek_pending_target());
+            } else {
+                draw_clean_paused(fb);
+            }
+        }
     } else {
         if (inp & INP_SELECT) { submenu_open(fb); draw_submenu(fb); input_drain(); return PLAYER_FRAME_HANDLED; }
-        if (inp & INP_A) player_pause_toggle();
+        if (inp & INP_A) {
+            player_pause_toggle();
+            if (g_paused) pause_screen_begin(fb);
+        }
         if (inp & INP_LEFT)  seek_accumulate(-SEEK_STEP, loop_now);
         if (inp & INP_RIGHT) seek_accumulate(+SEEK_STEP, loop_now);
         if (!g_pageflip_mode) {
@@ -3825,7 +3899,12 @@ static int player_handle_input(FBDev *fb, int inp, double loop_now)
             }
         }
 
-        if (loop_now - g_last_progress_report >= PROGRESS_REPORT_INTERVAL) {
+        if (g_paused) {
+            if (g_pause_ui.visible)
+                draw_paused(fb, g_info_item.name, seek_pending_target());
+            else
+                draw_clean_paused(fb);
+        } else if (loop_now - g_last_progress_report >= PROGRESS_REPORT_INTERVAL) {
             g_last_progress_report = loop_now;
             report_progress_async(g_info_item.id, g_play_session_id,
                                   (int64_t)(play_position() * 10000000.0), 0);
@@ -3876,6 +3955,8 @@ static void play(FBDev *fb, const char *item_id, double offset_secs)
     g_play_offset     = offset_secs > 0.0 ? offset_secs : 0.0;
     g_play_start_wall = now_sec();
     g_paused          = 0;
+    pause_ui_hide(&g_pause_ui);
+    g_pause_frame_current = 0;
     g_last_progress_report = now_sec();
     jf_report_start(&g_cfg, item_id, g_play_session_id, start_ticks, "Transcode");
 
@@ -5934,6 +6015,7 @@ int main(int argc, char **argv)
     sfx_shutdown();
     jf_log_close();
     player_stop();
+    free(g_pause_frame);
     info_assets_free();
     ddr_close();
     cursor_show();

--- a/src/pause_ui.c
+++ b/src/pause_ui.c
@@ -1,0 +1,23 @@
+#include "pause_ui.h"
+
+void pause_ui_hide(PauseUi *ui)
+{
+    ui->visible = 0;
+    ui->hide_at = 0.0;
+}
+
+int pause_ui_reveal(PauseUi *ui, double now)
+{
+    int was_hidden = !ui->visible;
+    ui->visible = 1;
+    ui->hide_at = now + PAUSE_UI_TIMEOUT_SECONDS;
+    return was_hidden;
+}
+
+int pause_ui_expire(PauseUi *ui, double now)
+{
+    if (!ui->visible || now < ui->hide_at) return 0;
+    ui->visible = 0;
+    ui->hide_at = 0.0;
+    return 1;
+}

--- a/src/pause_ui.h
+++ b/src/pause_ui.h
@@ -1,0 +1,20 @@
+#ifndef PAUSE_UI_H
+#define PAUSE_UI_H
+
+#define PAUSE_UI_TIMEOUT_SECONDS 3.0
+
+/* Video pause-overlay visibility and timeout. */
+typedef struct {
+    int visible;
+    double hide_at;
+} PauseUi;
+
+/* Hides the controls and cancels any active deadline. */
+void pause_ui_hide(PauseUi *ui);
+/* Returns nonzero when hidden controls became visible, so the waking input
+ * can be consumed instead of also performing its normal action. */
+int  pause_ui_reveal(PauseUi *ui, double now);
+/* Returns nonzero only on the visible-to-hidden deadline transition. */
+int  pause_ui_expire(PauseUi *ui, double now);
+
+#endif

--- a/tests/test_pause_ui.c
+++ b/tests/test_pause_ui.c
@@ -1,0 +1,48 @@
+/* Video pause-overlay state.
+ *
+ * Every pause stays clean until directional input asks for the controls.
+ * These transitions are easy to regress because playback, seeking, and the
+ * track submenu all share the same underlying mplayer pause command. */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "pause_ui.h"
+
+static int checks;
+#define CHECK(cond, msg) do { checks++; if (!(cond)) { \
+    printf("  FAIL %s (%s:%d)\n", msg, __FILE__, __LINE__); exit(1); } } while (0)
+
+int main(void)
+{
+    PauseUi ui = {.visible = 1, .hide_at = 99.0};
+    pause_ui_hide(&ui);
+    CHECK(!ui.visible, "a new playback starts with the overlay hidden");
+    CHECK(ui.hide_at == 0.0, "a new playback clears any old deadline");
+
+    pause_ui_hide(&ui);
+    CHECK(!ui.visible, "the first pause stays clean");
+    CHECK(ui.hide_at == 0.0, "pausing alone does not start a deadline");
+
+    CHECK(pause_ui_reveal(&ui, 20.0), "the first direction wakes hidden controls");
+    CHECK(ui.visible, "directional input reveals the overlay");
+    CHECK(ui.hide_at == 23.0, "a reveal starts a new three-second deadline");
+    CHECK(!pause_ui_reveal(&ui, 22.0), "direction on visible controls is not another wake");
+    CHECK(ui.hide_at == 25.0, "more directional input extends the deadline");
+    CHECK(!pause_ui_expire(&ui, 24.0), "the extended deadline is honored");
+    CHECK(pause_ui_expire(&ui, 25.0), "the overlay expires at its deadline");
+    CHECK(!ui.visible, "expiration restores the clean pause screen");
+    CHECK(!pause_ui_expire(&ui, 26.0), "an already hidden overlay does not expire twice");
+
+    CHECK(pause_ui_reveal(&ui, 30.0), "controls can be woken again");
+    pause_ui_hide(&ui);
+    CHECK(!ui.visible, "resuming hides the overlay");
+    CHECK(ui.hide_at == 0.0, "resuming cancels the deadline");
+    pause_ui_hide(&ui);
+    CHECK(!ui.visible, "a later pause stays clean");
+    CHECK(pause_ui_reveal(&ui, 31.0), "direction wakes controls after a later pause");
+    CHECK(ui.visible, "directional input still reveals controls on a later pause");
+
+    printf("pause ui: %d checks, 0 failures\n", checks);
+    return 0;
+}


### PR DESCRIPTION
## Overview

The existing video pause screen always displayed the full controls overlay over the frozen frame. This made it impossible to pause on a clean image.

This change keeps the video frame clean whenever playback is paused. Pressing any D-pad direction reveals the existing pause controls for three seconds. The first directional press only wakes the controls. Once the controls are visible, left and right retain their existing seek behavior. Resuming and pausing again returns directly to a clean frame.

## Implementation

- Capture the undecorated video frame when playback enters pause.
- Compose the controls from that saved frame so the overlay can be removed without leaving graphics behind.
- Continue presenting the clean saved frame while paused to preserve page-flip recovery and global message-banner animation.
- Keep pause visibility and timeout transitions in a small testable module.
- Leave audio playback and the existing track submenu behavior unchanged.

## Testing

- `make`
- ARM cross-build with Zig for `arm-linux-gnueabihf`
- Complete `make test` suite in the no-ALSA environment expected by the existing `test_sfx`
- Strict C11 pause-state test with warnings treated as errors: 19 checks passed
- Verified pause, directional wake, three-second hide, resume, and repeated pause behavior on real MiSTer hardware
